### PR TITLE
Allow for MultiArch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM golang:alpine AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+    GOOS=linux
 
 RUN apk add git
 


### PR DESCRIPTION
Remove `GOARCH=amd64` to allow for MultiArch builds.

Builds are testing fine for amd64 / arm64.