### PR TITLE
Add suport for TLS based HTTP connections.

### DIFF
--- a/parser/configurations_parser.go
+++ b/parser/configurations_parser.go
@@ -68,6 +68,8 @@ type BeelzebubServiceConfiguration struct {
 	Description            string    `yaml:"description"`
 	Banner                 string    `yaml:"banner"`
 	Plugin                 Plugin    `yaml:"plugin"`
+	TLSCertPath            string    `yaml:"tlsCertPath"`
+	TLSKeyPath             string    `yaml:"tlsKeyPath"`
 }
 
 // Command is the struct that contains the configurations of the commands

--- a/parser/configurations_parser_test.go
+++ b/parser/configurations_parser_test.go
@@ -49,6 +49,8 @@ func mockReadfilebytesBeelzebubServiceConfiguration(filePath string) ([]byte, er
 apiVersion: "v1"
 protocol: "http"
 address: ":8080"
+tlsCertPath: "/tmp/cert.crt"
+tlsKeyPath: "/tmp/cert.key"
 commands:
   - regex: "wp-admin"
     handler: "login"
@@ -135,6 +137,8 @@ func TestReadConfigurationsServicesValid(t *testing.T) {
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Plugin.LLMModel, "llama3")
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Plugin.Host, "localhost:1563")
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Plugin.Prompt, "hello world")
+	assert.Equal(t, firstBeelzebubServiceConfiguration.TLSCertPath, "/tmp/cert.crt")
+	assert.Equal(t, firstBeelzebubServiceConfiguration.TLSKeyPath, "/tmp/cert.key")
 }
 
 func TestGelAllFilesNameByDirName(t *testing.T) {

--- a/protocols/strategies/http.go
+++ b/protocols/strategies/http.go
@@ -2,14 +2,15 @@ package strategies
 
 import (
 	"fmt"
-	"github.com/mariocandela/beelzebub/v3/parser"
-	"github.com/mariocandela/beelzebub/v3/plugins"
-	"github.com/mariocandela/beelzebub/v3/tracer"
 	"io"
 	"net"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/mariocandela/beelzebub/v3/parser"
+	"github.com/mariocandela/beelzebub/v3/plugins"
+	"github.com/mariocandela/beelzebub/v3/tracer"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -67,13 +68,25 @@ func (httpStrategy HTTPStrategy) Init(beelzebubServiceConfiguration parser.Beelz
 				}
 
 				setResponseHeaders(responseWriter, command.Headers, command.StatusCode)
-				fmt.Fprintf(responseWriter, responseHTTPBody)
+				fmt.Fprint(responseWriter, responseHTTPBody)
 				break
 			}
 		}
 	})
 	go func() {
-		err := http.ListenAndServe(httpStrategy.beelzebubServiceConfiguration.Address, serverMux)
+		var err error
+		// Launch a TLS supporting server if we are supplied a TLS Key and Certificate.
+		// If relative paths are supplied, they are relative to the CWD of the binary.
+		// The can be self-signed, only the client will validate this (or not).
+		if httpStrategy.beelzebubServiceConfiguration.TLSKeyPath != "" && httpStrategy.beelzebubServiceConfiguration.TLSCertPath != "" {
+			err = http.ListenAndServeTLS(
+				httpStrategy.beelzebubServiceConfiguration.Address,
+				httpStrategy.beelzebubServiceConfiguration.TLSCertPath,
+				httpStrategy.beelzebubServiceConfiguration.TLSKeyPath,
+				serverMux)
+		} else {
+			err = http.ListenAndServe(httpStrategy.beelzebubServiceConfiguration.Address, serverMux)
+		}
 		if err != nil {
 			log.Errorf("Error during init HTTP Protocol: %s", err.Error())
 			return
@@ -95,7 +108,7 @@ func traceRequest(request *http.Request, tr tracer.Tracer, HoneypotDescription s
 	}
 	host, port, _ := net.SplitHostPort(request.RemoteAddr)
 
-	tr.TraceEvent(tracer.Event{
+	event := tracer.Event{
 		Msg:             "HTTP New request",
 		RequestURI:      request.RequestURI,
 		Protocol:        tracer.HTTP.String(),
@@ -111,7 +124,13 @@ func traceRequest(request *http.Request, tr tracer.Tracer, HoneypotDescription s
 		SourcePort:      port,
 		ID:              uuid.New().String(),
 		Description:     HoneypotDescription,
-	})
+	}
+	// Capture the TLS details from the request, if provided.
+	if request.TLS != nil {
+		event.Msg = "HTTPS New Request"
+		event.TLSServerName = request.TLS.ServerName
+	}
+	tr.TraceEvent(event)
 }
 
 func mapHeaderToString(headers http.Header) string {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -2,9 +2,10 @@
 package tracer
 
 import (
-	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -36,6 +37,7 @@ type Event struct {
 	Description     string
 	SourceIp        string
 	SourcePort      string
+	TLSServerName   string
 }
 
 type (


### PR DESCRIPTION
Add support for TLS in the HTTP strategy.

This adds 2 new optional fields to the Strategy configuration - `TLSKeyPath` and `TLSCertPath`. These are passed as provided to the `http.ListenAndServeTLS` function if they are not empty. Missing and invalid file path errors are handled by the underlying library.

Also correct a function typo (`Fprintf` was used, but no format string was provided), and reorder imports to improve readbility.


---
 All Submissions:

* [X ] Have you followed the guidelines in our Contributing document?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X ] Does your submission pass tests?
2. [X ] Have you lint your code locally before submission?

### Changes to Core Features:

* [ X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X] Have you written new tests for your core changes, as applicable?
* [ X] Have you successfully run tests with your changes locally?
