### PR TITLE
Update Docker commands to use new syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ You can run Beelzebub via Docker, Go compiler(cross device), or Helm (Kubernetes
 1. Build the Docker images:
 
    ```bash
-   $ docker-compose build
+   $ docker compose build
    ```
 
 2. Start Beelzebub in detached mode:
 
    ```bash
-   $ docker-compose up -d
+   $ docker compose up -d
    ```
 
 


### PR DESCRIPTION
meglio usare la nuova syntax che tratta il compose come plugin, quindi:
docker compose [...]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker command examples in the README to reflect the newer `docker compose` syntax, replacing the legacy `docker-compose` commands for improved compatibility with current Docker installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->