### PR TITLE
feat(tcp): add binary-safe frame reading and RESP2 reply framing

### DIFF
--- a/configurations/services/tcp-6379-redis.yaml
+++ b/configurations/services/tcp-6379-redis.yaml
@@ -1,0 +1,71 @@
+# Redis 7.2.4 — binary-safe RESP2 honeypot
+#
+# Uses binarySafe: true and replyFormat: redis-* so real RESP2 clients
+# (redis-cli, redis-py, go-redis, ioredis, jedis, ...) get wire-correct
+# replies. Verified against redis-cli 7.0.15 and redis-py 7.4.0.
+#
+# Each handler declares its reply format; encodeReply in the TCP
+# strategy frames the bytes per https://redis.io/docs/latest/develop/reference/protocol-spec/.
+
+apiVersion: "v1"
+protocol: "tcp"
+address: ":6379"
+description: "Redis 7.2.4"
+deadlineTimeoutSeconds: 60
+binarySafe: true
+
+commands:
+  # RESP3 negotiation: reply with NOPROTO so clients fall back to RESP2.
+  - regex: "^(?i)HELLO(\\s+.*)?$"
+    replyFormat: "redis-error"
+    handler: "NOPROTO unsupported protocol version"
+    name: "hello"
+
+  # CLIENT SETINFO / SETNAME / NO-EVICT / etc. — client init chatter.
+  - regex: "^(?i)CLIENT\\s+(SETINFO|SETNAME|NO-EVICT|UNPAUSE|REPLY)(\\s+.*)?$"
+    replyFormat: "redis-simple"
+    handler: "OK"
+    name: "client_setters"
+
+  - regex: "^(?i)PING$"
+    replyFormat: "redis-simple"
+    handler: "PONG"
+    name: "ping"
+
+  - regex: "^(?i)AUTH(\\s+.*)?$"
+    replyFormat: "redis-error"
+    handler: "ERR Client sent AUTH, but no password is set. Try CONFIG SET requirepass."
+    name: "auth"
+
+  - regex: "^(?i)INFO(\\s+\\w+)?$"
+    replyFormat: "redis-bulk"
+    handler: |
+      # Server
+      redis_version:7.2.4
+      redis_git_sha1:00000000
+      redis_mode:standalone
+      os:Linux 5.15.0-generic x86_64
+      arch_bits:64
+      tcp_port:6379
+      uptime_in_seconds:2847391
+      # Clients
+      connected_clients:3
+      # Memory
+      used_memory:1247896
+      # Stats
+      total_connections_received:58234
+    name: "info"
+
+  - regex: "^(?i)COMMAND(\\s+.*)?$"
+    replyFormat: "redis-array"
+    replyBulks:
+      - "get"
+      - "set"
+      - "ping"
+      - "info"
+    name: "command"
+
+  - regex: "^(.+)$"
+    replyFormat: "redis-error"
+    handler: "ERR unknown command"
+    name: "catch_all"

--- a/parser/configurations_parser.go
+++ b/parser/configurations_parser.go
@@ -85,6 +85,13 @@ type BeelzebubServiceConfiguration struct {
 	Plugin                 Plugin    `yaml:"plugin"`
 	TLSCertPath            string    `yaml:"tlsCertPath"`
 	TLSKeyPath             string    `yaml:"tlsKeyPath"`
+	// BinarySafe switches the TCP strategy from its default banner-and-read
+	// behavior to a frame-aware reader that preserves every byte (CR/LF,
+	// non-printable, multi-line payloads) and enables RESP2-aware reply
+	// framing via Command.ReplyFormat. Intended for binary wire protocols
+	// like Redis RESP2 where a regex on a line-mangled read cannot match.
+	// Defaults to false; existing TCP configs are unaffected.
+	BinarySafe bool `yaml:"binarySafe" json:",omitempty"`
 }
 
 func (bsc BeelzebubServiceConfiguration) HashCode() (string, error) {
@@ -105,6 +112,26 @@ type Command struct {
 	StatusCode int            `yaml:"statusCode"`
 	Plugin     string         `yaml:"plugin"`
 	Name       string         `yaml:"name"`
+	// ReplyFormat selects the wire encoding for this command's reply when
+	// the enclosing service sets binarySafe: true. Empty string preserves
+	// the legacy plain-text behavior (handler + "\r\n"). Supported values
+	// for Redis RESP2:
+	//
+	//   "redis-simple"   -> "+<handler>\r\n"
+	//   "redis-integer"  -> ":<handler>\r\n"
+	//   "redis-error"    -> "-<handler>\r\n"
+	//   "redis-bulk"     -> "$<len>\r\n<handler>\r\n" (length auto-computed)
+	//   "redis-nil-bulk" -> "$-1\r\n"
+	//   "redis-array"    -> "*<n>\r\n" + per-entry bulk encoding drawn from ReplyBulks
+	//   "redis-raw"      -> handler bytes written verbatim (escape hatch for
+	//                       nested RESP shapes the typed encoders can't express)
+	//
+	// Any unrecognized value falls through to the legacy plaintext behavior
+	// with a logged warning, so a YAML typo does not silently drop traffic.
+	ReplyFormat string `yaml:"replyFormat,omitempty" json:",omitempty"`
+	// ReplyBulks supplies the per-entry bulk-string payload for replies
+	// emitted with ReplyFormat: "redis-array". Ignored otherwise.
+	ReplyBulks []string `yaml:"replyBulks,omitempty" json:",omitempty"`
 }
 
 // Tool is the struct that contains the configurations of the MCP Honeypot

--- a/parser/configurations_parser_test.go
+++ b/parser/configurations_parser_test.go
@@ -546,6 +546,24 @@ func TestToolAnnotationsHashCodeStability(t *testing.T) {
 	assert.Equal(t, "528e52a4b7addc43ec887dba7913070c9fd9f2ec246723c4b6ee73de75426e24", hashCode)
 }
 
+// Verifies that the new BinarySafe / ReplyFormat / ReplyBulks fields
+// do not alter the HashCode of existing configs that leave them unset.
+// This is the same backward-compatibility guarantee the ToolAnnotations
+// addition established.
+func TestBinarySafeReplyFormatHashCodeStability(t *testing.T) {
+	configurationsParser := Init("", "")
+	configurationsParser.readFileBytesByFilePathDependency = mockReadfilebytesBeelzebubServiceConfiguration
+	configurationsParser.gelAllFilesNameByDirNameDependency = mockReadDirValid
+
+	cfgs, err := configurationsParser.ReadConfigurationsServices()
+	assert.Nil(t, err)
+
+	hashCode, errHashCode := cfgs[0].HashCode()
+	assert.Nil(t, errHashCode)
+	assert.Equal(t, "528e52a4b7addc43ec887dba7913070c9fd9f2ec246723c4b6ee73de75426e24", hashCode,
+		"adding BinarySafe/ReplyFormat/ReplyBulks with omitempty must not change the hash of existing configs")
+}
+
 func TestReadConfigurationsCoreEnvOverridesFile(t *testing.T) {
 	t.Setenv("BEELZEBUB_PROMETHEUS_PORT", ":9999")
 	t.Setenv("BEELZEBUB_PROMETHEUS_PATH", "/custom-metrics")

--- a/protocols/strategies/TCP/tcp.go
+++ b/protocols/strategies/TCP/tcp.go
@@ -26,7 +26,14 @@ func (tcpStrategy *TCPStrategy) Init(servConf parser.BeelzebubServiceConfigurati
 		for {
 			if conn, err := listen.Accept(); err == nil {
 				go func() {
+					defer conn.Close()
 					conn.SetDeadline(time.Now().Add(time.Duration(servConf.DeadlineTimeoutSeconds) * time.Second))
+
+					if servConf.BinarySafe {
+						handleBinarySafeConnection(conn, servConf, tr)
+						return
+					}
+
 					conn.Write(fmt.Appendf([]byte{}, "%s\n", servConf.Banner))
 
 					buffer := make([]byte, 1024)
@@ -49,7 +56,6 @@ func (tcpStrategy *TCPStrategy) Init(servConf parser.BeelzebubServiceConfigurati
 						ID:          uuid.New().String(),
 						Description: servConf.Description,
 					})
-					conn.Close()
 				}()
 			}
 		}

--- a/protocols/strategies/TCP/tcp_binarysafe.go
+++ b/protocols/strategies/TCP/tcp_binarysafe.go
@@ -1,0 +1,377 @@
+// Binary-safe interactive TCP handler. Opts in via `binarySafe: true` on
+// the service config. Preserves every byte on the wire so Redis RESP2
+// (`*1\r\n$4\r\nPING\r\n`) and similar multi-line binary protocols can
+// be matched and answered without going through a line-mangling read.
+//
+// RESP2 encodings follow https://redis.io/docs/latest/develop/reference/protocol-spec/.
+
+package TCP
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mariocandela/beelzebub/v3/parser"
+	"github.com/mariocandela/beelzebub/v3/tracer"
+)
+
+// Upper bound on a single captured frame, in bytes. Protects against
+// unbounded reads from misbehaving clients.
+const binarySafeMaxFrame = 8192
+
+// Short read deadline applied after the first byte arrives. A pause
+// longer than this ends the current frame. 50 ms cleanly separates
+// back-to-back RESP2 requests on one connection while remaining
+// imperceptible to legitimate clients.
+const binarySafeSettleWindow = 50 * time.Millisecond
+
+// handleBinarySafeConnection runs the binary-safe request loop on one
+// accepted connection. The caller sets the initial deadline and owns
+// the conn lifecycle (close).
+func handleBinarySafeConnection(conn net.Conn, servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) {
+	// Byte-exact banner. No appended newline: operators include one if they want one.
+	if servConf.Banner != "" {
+		_, _ = conn.Write([]byte(servConf.Banner))
+	}
+
+	sessionDeadline := time.Duration(servConf.DeadlineTimeoutSeconds) * time.Second
+	if sessionDeadline <= 0 {
+		sessionDeadline = 30 * time.Second
+	}
+
+	host, port, _ := net.SplitHostPort(conn.RemoteAddr().String())
+
+	for {
+		rawBytes, err := readBinaryFrame(conn, sessionDeadline)
+		if err != nil && len(rawBytes) == 0 {
+			return
+		}
+		if len(rawBytes) == 0 {
+			return
+		}
+
+		// Refresh the session-level deadline so long interactive sessions aren't cut mid-stream.
+		_ = conn.SetDeadline(time.Now().Add(sessionDeadline))
+
+		commandRawHex := hexEscapeNonPrintable(rawBytes)
+		commandInput := decodeProtocolCommand(rawBytes)
+		if commandInput == "" {
+			continue
+		}
+
+		matchedCommand, commandOutput, handlerName := matchCommand(servConf, commandInput)
+
+		wireBytes := encodeReply(matchedCommand, commandOutput)
+		if len(wireBytes) > 0 {
+			if _, err := conn.Write(wireBytes); err != nil {
+				return
+			}
+		}
+
+		tr.TraceEvent(tracer.Event{
+			Msg:           "TCP binary-safe interaction",
+			Protocol:      tracer.TCP.String(),
+			Status:        tracer.Interaction.String(),
+			Command:       commandInput,
+			CommandRaw:    commandRawHex,
+			CommandOutput: commandOutput,
+			RemoteAddr:    conn.RemoteAddr().String(),
+			SourceIp:      host,
+			SourcePort:    port,
+			ID:            uuid.New().String(),
+			Description:   servConf.Description,
+			Handler:       handlerName,
+		})
+	}
+}
+
+// matchCommand finds the first Command whose Regex matches commandInput,
+// falling back to servConf.FallbackCommand when nothing matches. Returns
+// the selected Command, its handler string, and a human-readable name
+// for the trace event.
+func matchCommand(servConf parser.BeelzebubServiceConfiguration, commandInput string) (parser.Command, string, string) {
+	for _, command := range servConf.Commands {
+		if command.Regex == nil || !command.Regex.MatchString(commandInput) {
+			continue
+		}
+		name := command.Name
+		if name == "" {
+			name = "configured_regex"
+		}
+		return command, command.Handler, name
+	}
+
+	fb := servConf.FallbackCommand
+	name := "not_found"
+	if fb.Name != "" {
+		name = fb.Name
+	} else if fb.Handler != "" || fb.ReplyFormat != "" {
+		name = "fallback"
+	}
+	return fb, fb.Handler, name
+}
+
+// readBinaryFrame reads one logical request frame from conn. It returns
+// when any of the following is true, whichever comes first:
+//
+//   - the client stops sending for binarySafeSettleWindow (end of frame);
+//   - binarySafeMaxFrame bytes have been collected;
+//   - the connection closes;
+//   - sessionDeadline expires before any byte arrives.
+//
+// Bytes are never converted through string — CRLF and non-printable
+// bytes survive intact.
+func readBinaryFrame(conn net.Conn, sessionDeadline time.Duration) ([]byte, error) {
+	buf := make([]byte, 0, 256)
+	chunk := make([]byte, 256)
+
+	// Wait the full session deadline for the first byte.
+	if err := conn.SetReadDeadline(time.Now().Add(sessionDeadline)); err != nil {
+		return buf, err
+	}
+	n, err := conn.Read(chunk)
+	if n > 0 {
+		buf = append(buf, chunk[:n]...)
+	}
+	if err != nil {
+		if err == io.EOF {
+			return buf, err
+		}
+		if len(buf) == 0 {
+			return buf, err
+		}
+	}
+
+	// Short reads until the client pauses or the frame fills.
+	for len(buf) < binarySafeMaxFrame {
+		if err := conn.SetReadDeadline(time.Now().Add(binarySafeSettleWindow)); err != nil {
+			break
+		}
+		n, err := conn.Read(chunk)
+		if n > 0 {
+			remaining := binarySafeMaxFrame - len(buf)
+			if n > remaining {
+				n = remaining
+			}
+			buf = append(buf, chunk[:n]...)
+		}
+		if err != nil {
+			// Settle timeout ends the frame; not a propagated error.
+			break
+		}
+	}
+
+	// Restore the session deadline for subsequent I/O.
+	_ = conn.SetReadDeadline(time.Now().Add(sessionDeadline))
+	return buf, nil
+}
+
+// decodeProtocolCommand returns a regex-friendly logical command string
+// extracted from raw frame bytes. It auto-detects the wire format from
+// the first bytes:
+//
+//   - `*N\r\n$L\r\nCMD\r\n...`                          RESP2 array        -> "CMD ARG1 ARG2"
+//   - `+OK\r\n` / `-ERR x\r\n` / `:42\r\n` / `$N...`    RESP2 simple types -> returned CRLF-stripped
+//   - Mostly-printable ASCII                            telnet-like        -> CRLF-stripped
+//   - Binary / unknown                                  fallthrough        -> hex-escaped
+//
+// Never returns an empty string for non-empty input; never panics.
+func decodeProtocolCommand(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+
+	if b[0] == '*' {
+		if cmd := decodeRESPArray(b); cmd != "" {
+			return cmd
+		}
+		// Malformed RESP array — fall through to hex.
+	}
+
+	if b[0] == '+' || b[0] == '-' || b[0] == ':' || b[0] == '$' {
+		return strings.TrimRight(string(b), "\r\n\x00")
+	}
+
+	if isMostlyPrintable(b) {
+		return strings.TrimRight(string(b), "\r\n\x00 \t")
+	}
+
+	return hexEscapeNonPrintable(b)
+}
+
+// decodeRESPArray parses a RESP2 array frame per
+// https://redis.io/docs/latest/develop/reference/protocol-spec/ and
+// returns a space-joined "CMD ARG1 ARG2 ...". An empty string means
+// malformed or truncated with no arguments recovered; a partial input
+// that parsed at least one argument returns that prefix.
+func decodeRESPArray(b []byte) string {
+	if len(b) < 4 || b[0] != '*' {
+		return ""
+	}
+	end := bytesIndexCRLF(b)
+	if end < 2 {
+		return ""
+	}
+
+	count := 0
+	for _, c := range b[1:end] {
+		if c < '0' || c > '9' {
+			return ""
+		}
+		count = count*10 + int(c-'0')
+	}
+	// Sanity cap. Real Redis commands rarely exceed a handful of arguments.
+	if count <= 0 || count > 64 {
+		return ""
+	}
+
+	pos := end + 2
+	parts := make([]string, 0, count)
+
+	for i := 0; i < count; i++ {
+		if pos >= len(b) || b[pos] != '$' {
+			return ""
+		}
+		hdrEnd := bytesIndexCRLFFrom(b, pos)
+		if hdrEnd < 0 {
+			return ""
+		}
+
+		bulkLen := 0
+		for _, c := range b[pos+1 : hdrEnd] {
+			if c < '0' || c > '9' {
+				return ""
+			}
+			bulkLen = bulkLen*10 + int(c-'0')
+		}
+		if bulkLen < 0 || bulkLen > binarySafeMaxFrame {
+			return ""
+		}
+
+		valStart := hdrEnd + 2
+		valEnd := valStart + bulkLen
+		if valEnd > len(b) {
+			if len(parts) > 0 {
+				return strings.Join(parts, " ")
+			}
+			return ""
+		}
+
+		parts = append(parts, string(b[valStart:valEnd]))
+		pos = valEnd + 2
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// bytesIndexCRLF returns the index of the first `\r\n` in b, or -1.
+func bytesIndexCRLF(b []byte) int {
+	for i := 0; i < len(b)-1; i++ {
+		if b[i] == '\r' && b[i+1] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+// bytesIndexCRLFFrom returns the index of the first `\r\n` at or after
+// from, or -1.
+func bytesIndexCRLFFrom(b []byte, from int) int {
+	if from < 0 {
+		from = 0
+	}
+	for i := from; i < len(b)-1; i++ {
+		if b[i] == '\r' && b[i+1] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+// isMostlyPrintable reports whether at least 90% of b is printable
+// ASCII or whitespace. Empty input returns false.
+func isMostlyPrintable(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	printable := 0
+	for _, c := range b {
+		if (c >= 32 && c <= 126) || c == '\t' || c == '\n' || c == '\r' {
+			printable++
+		}
+	}
+	return printable*10 >= len(b)*9
+}
+
+// hexEscapeNonPrintable returns a printable-ASCII rendering of b. Bytes
+// outside the printable ASCII range are emitted as `\xNN`. The
+// backslash itself is escaped for unambiguous decoding. Safe for JSON,
+// database TEXT columns, and log lines.
+func hexEscapeNonPrintable(b []byte) string {
+	var sb strings.Builder
+	sb.Grow(len(b))
+	for _, c := range b {
+		if c >= 32 && c <= 126 && c != '\\' {
+			sb.WriteByte(c)
+		} else {
+			fmt.Fprintf(&sb, "\\x%02x", c)
+		}
+	}
+	return sb.String()
+}
+
+// encodeReply returns the wire bytes for one reply, honoring
+// cmd.ReplyFormat. When ReplyFormat is empty, the legacy behavior is
+// preserved: `value + "\r\n"`. Unrecognized values log a warning and
+// fall back to plaintext so a YAML typo does not silently drop a
+// reply.
+//
+// RESP2 encodings (per redis.io protocol spec):
+//
+//	redis-simple   -> "+<value>\r\n"
+//	redis-integer  -> ":<value>\r\n"
+//	redis-error    -> "-<value>\r\n"
+//	redis-bulk     -> "$<len>\r\n<value>\r\n"
+//	redis-nil-bulk -> "$-1\r\n"
+//	redis-raw      -> value written verbatim
+//	redis-array    -> "*<n>\r\n" followed by per-entry bulk encoding of cmd.ReplyBulks
+func encodeReply(cmd parser.Command, value string) []byte {
+	switch cmd.ReplyFormat {
+	case "":
+		if value == "" {
+			return nil
+		}
+		return []byte(value + "\r\n")
+	case "redis-simple":
+		return []byte("+" + value + "\r\n")
+	case "redis-integer":
+		return []byte(":" + value + "\r\n")
+	case "redis-error":
+		return []byte("-" + value + "\r\n")
+	case "redis-bulk":
+		return []byte(fmt.Sprintf("$%d\r\n%s\r\n", len(value), value))
+	case "redis-nil-bulk":
+		return []byte("$-1\r\n")
+	case "redis-raw":
+		return []byte(value)
+	case "redis-array":
+		var buf strings.Builder
+		fmt.Fprintf(&buf, "*%d\r\n", len(cmd.ReplyBulks))
+		for _, entry := range cmd.ReplyBulks {
+			fmt.Fprintf(&buf, "$%d\r\n%s\r\n", len(entry), entry)
+		}
+		return []byte(buf.String())
+	default:
+		log.Warnf("tcp.encodeReply: unknown replyFormat %q, falling back to plaintext", cmd.ReplyFormat)
+		if value == "" {
+			return nil
+		}
+		return []byte(value + "\r\n")
+	}
+}

--- a/protocols/strategies/TCP/tcp_binarysafe_test.go
+++ b/protocols/strategies/TCP/tcp_binarysafe_test.go
@@ -1,0 +1,508 @@
+package TCP
+
+import (
+	"net"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mariocandela/beelzebub/v3/parser"
+	"github.com/mariocandela/beelzebub/v3/tracer"
+	"github.com/stretchr/testify/assert"
+)
+
+// ─── decodeProtocolCommand ────────────────────────────────────────────
+
+func TestDecodeProtocolCommand_RESP2Ping(t *testing.T) {
+	frame := []byte("*1\r\n$4\r\nPING\r\n")
+	assert.Equal(t, "PING", decodeProtocolCommand(frame))
+}
+
+func TestDecodeProtocolCommand_RESP2SetKeyValue(t *testing.T) {
+	frame := []byte("*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n")
+	assert.Equal(t, "SET foo bar", decodeProtocolCommand(frame))
+}
+
+func TestDecodeProtocolCommand_RESP2Info(t *testing.T) {
+	frame := []byte("*1\r\n$4\r\nINFO\r\n")
+	assert.Equal(t, "INFO", decodeProtocolCommand(frame))
+}
+
+func TestDecodeProtocolCommand_RESP2ClientList(t *testing.T) {
+	frame := []byte("*2\r\n$6\r\nCLIENT\r\n$4\r\nLIST\r\n")
+	assert.Equal(t, "CLIENT LIST", decodeProtocolCommand(frame))
+}
+
+func TestDecodeProtocolCommand_RESP2Lowercase(t *testing.T) {
+	frame := []byte("*1\r\n$4\r\nping\r\n")
+	assert.Equal(t, "ping", decodeProtocolCommand(frame))
+}
+
+func TestDecodeProtocolCommand_RESP2TruncatedReturnsPrefix(t *testing.T) {
+	// SET foo bar with `bar` cut off after one byte.
+	frame := []byte("*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nb")
+	got := decodeProtocolCommand(frame)
+	assert.NotEmpty(t, got, "truncated RESP should return a parseable prefix, not nothing")
+	assert.True(t, strings.HasPrefix(got, "SET foo"), "expected prefix 'SET foo', got %q", got)
+}
+
+func TestDecodeProtocolCommand_RESP2MalformedFallsToHex(t *testing.T) {
+	// `*` followed by non-digit.
+	frame := []byte("*z\r\nGarbage")
+	got := decodeProtocolCommand(frame)
+	assert.NotEmpty(t, got, "malformed RESP should still return the hex-escaped form, not empty")
+}
+
+func TestDecodeProtocolCommand_RESP2SimpleTypes(t *testing.T) {
+	// RESP2 simple string / error / integer / bulk-header — returned CRLF-stripped.
+	cases := map[string]string{
+		"+OK\r\n":                  "+OK",
+		"-ERR unknown command\r\n": "-ERR unknown command",
+		":42\r\n":                  ":42",
+		"$5\r\nhello\r\n":          "$5\r\nhello", // bulk header + payload; trimmed trailing CRLF
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, decodeProtocolCommand([]byte(in)), "input %q", in)
+	}
+}
+
+func TestDecodeProtocolCommand_PlainASCII(t *testing.T) {
+	assert.Equal(t, "hello world", decodeProtocolCommand([]byte("hello world\r\n")))
+}
+
+func TestDecodeProtocolCommand_BinaryFallsToHex(t *testing.T) {
+	frame := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
+	got := decodeProtocolCommand(frame)
+	assert.Contains(t, got, `\x00`, "binary input should be hex-escaped")
+}
+
+func TestDecodeProtocolCommand_Empty(t *testing.T) {
+	assert.Equal(t, "", decodeProtocolCommand([]byte{}))
+}
+
+// RESP array with argc=0 is treated as malformed by the RESP decoder.
+// The outer decoder falls through to plaintext trimming — that's fine;
+// the requirement is no panic and a non-empty capture.
+func TestDecodeProtocolCommand_RESP2ZeroArgCount(t *testing.T) {
+	got := decodeProtocolCommand([]byte("*0\r\n"))
+	assert.NotEmpty(t, got)
+}
+
+// RESP array with an absurd argc must not allocate wildly.
+func TestDecodeProtocolCommand_RESP2HugeArgCountRejected(t *testing.T) {
+	frame := []byte("*999999\r\n$4\r\nPING\r\n")
+	got := decodeProtocolCommand(frame)
+	// sanity cap rejects the count; decoder falls through to hex.
+	assert.NotEqual(t, "PING", got)
+}
+
+// RESP bulk-length overrun must not read past len(b). The RESP decoder
+// rejects the frame; the outer decoder falls through to plaintext
+// trimming, which is fine — we just need no crash and a non-empty capture.
+func TestDecodeProtocolCommand_RESP2BulkLenOverrun(t *testing.T) {
+	frame := []byte("*1\r\n$9999999\r\n")
+	got := decodeProtocolCommand(frame)
+	assert.NotEmpty(t, got, "malformed bulk-len should still yield some capture, not empty")
+	assert.NotContains(t, got, "PING", "should not spuriously decode as a RESP command")
+}
+
+// ─── hexEscapeNonPrintable ────────────────────────────────────────────
+
+func TestHexEscape_PreservesPrintable(t *testing.T) {
+	assert.Equal(t, "Hello, World!", hexEscapeNonPrintable([]byte("Hello, World!")))
+}
+
+func TestHexEscape_EscapesCRLF(t *testing.T) {
+	assert.Equal(t, `a\x0db\x0ac`, hexEscapeNonPrintable([]byte("a\rb\nc")))
+}
+
+func TestHexEscape_EscapesNull(t *testing.T) {
+	assert.Equal(t, `\x00A\x00`, hexEscapeNonPrintable([]byte{0x00, 0x41, 0x00}))
+}
+
+func TestHexEscape_EscapesBackslash(t *testing.T) {
+	// Backslash escapes itself so output is unambiguously decodable.
+	assert.Equal(t, `a\x5cb`, hexEscapeNonPrintable([]byte(`a\b`)))
+}
+
+func TestHexEscape_HighByte(t *testing.T) {
+	// Critical case: LDAP BindRequest CONTEXT 0 IMPLICIT tag = 0x80.
+	// Must survive as `\x80`, not a UTF-8 replacement character.
+	assert.Equal(t, `\x80`, hexEscapeNonPrintable([]byte{0x80}))
+}
+
+// ─── isMostlyPrintable ────────────────────────────────────────────────
+
+func TestIsMostlyPrintable(t *testing.T) {
+	cases := map[string]bool{
+		"hello":                           true,
+		"hello\r\nworld":                  true,
+		"":                                false, // empty is not "text"
+		string([]byte{0, 0, 0, 0}):        false,
+		"abcdefghi" + string([]byte{0}):   true,  // 9/10 printable
+		"abcdefgh" + string([]byte{0, 0}): false, // 8/10 printable
+	}
+	for input, want := range cases {
+		assert.Equal(t, want, isMostlyPrintable([]byte(input)), "input %q", input)
+	}
+}
+
+// ─── encodeReply — RESP2 format coverage ─────────────────────────────
+
+func TestEncodeReply_LegacyDefault(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: ""}
+	assert.Equal(t, []byte("hello\r\n"), encodeReply(cmd, "hello"))
+}
+
+func TestEncodeReply_LegacyEmptyValue(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: ""}
+	assert.Nil(t, encodeReply(cmd, ""), "legacy empty value should suppress reply entirely")
+}
+
+func TestEncodeReply_RedisSimple(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-simple"}
+	assert.Equal(t, []byte("+PONG\r\n"), encodeReply(cmd, "PONG"))
+}
+
+func TestEncodeReply_RedisInteger(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-integer"}
+	assert.Equal(t, []byte(":42\r\n"), encodeReply(cmd, "42"))
+}
+
+func TestEncodeReply_RedisError(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-error"}
+	assert.Equal(t, []byte("-ERR unknown command\r\n"), encodeReply(cmd, "ERR unknown command"))
+}
+
+func TestEncodeReply_RedisBulk(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-bulk"}
+	value := "redis_version:7.2.4"
+	got := encodeReply(cmd, value)
+	assert.Equal(t, []byte("$19\r\nredis_version:7.2.4\r\n"), got)
+}
+
+func TestEncodeReply_RedisBulkWithEmbeddedCRLF(t *testing.T) {
+	// RESP bulk strings are byte-exact: CRLF inside the value is preserved
+	// and the length prefix counts every byte.
+	cmd := parser.Command{ReplyFormat: "redis-bulk"}
+	value := "line1\r\nline2"
+	got := encodeReply(cmd, value)
+	assert.Equal(t, []byte("$12\r\nline1\r\nline2\r\n"), got, "bulk length must equal byte count of value, CRLF included")
+}
+
+func TestEncodeReply_RedisNilBulk(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-nil-bulk"}
+	// handler value is intentionally ignored.
+	assert.Equal(t, []byte("$-1\r\n"), encodeReply(cmd, "ignored"))
+}
+
+func TestEncodeReply_RedisRawVerbatim(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-raw"}
+	raw := "*3\r\n:1\r\n:2\r\n:3\r\n"
+	assert.Equal(t, []byte(raw), encodeReply(cmd, raw))
+}
+
+func TestEncodeReply_RedisArray(t *testing.T) {
+	cmd := parser.Command{
+		ReplyFormat: "redis-array",
+		ReplyBulks:  []string{"get", "set", "ping"},
+	}
+	got := encodeReply(cmd, "")
+	want := []byte("*3\r\n$3\r\nget\r\n$3\r\nset\r\n$4\r\nping\r\n")
+	assert.Equal(t, want, got)
+}
+
+func TestEncodeReply_RedisArrayEmpty(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-array", ReplyBulks: nil}
+	assert.Equal(t, []byte("*0\r\n"), encodeReply(cmd, ""))
+}
+
+func TestEncodeReply_UnknownFormatFallsBackToPlaintext(t *testing.T) {
+	cmd := parser.Command{ReplyFormat: "redis-unknown-xyz"}
+	got := encodeReply(cmd, "hello")
+	assert.Equal(t, []byte("hello\r\n"), got)
+}
+
+// ─── readBinaryFrame — uses net.Pipe for deterministic I/O ───────────
+
+// pipePair wraps a net.Pipe for server-side / client-side halves with
+// deadline support.
+func pipePair(t *testing.T) (server, client net.Conn) {
+	t.Helper()
+	s, c := net.Pipe()
+	t.Cleanup(func() { _ = s.Close(); _ = c.Close() })
+	return s, c
+}
+
+func TestReadBinaryFrame_CollectsSingleWrite(t *testing.T) {
+	server, client := pipePair(t)
+	frame := []byte("*1\r\n$4\r\nPING\r\n")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = client.Write(frame)
+		// Leave the connection open; readBinaryFrame should end via settle window.
+	}()
+
+	buf, err := readBinaryFrame(server, 2*time.Second)
+	wg.Wait()
+	assert.NoError(t, err)
+	assert.Equal(t, frame, buf, "single write should round-trip verbatim")
+}
+
+func TestReadBinaryFrame_CollectsBurstAcrossWrites(t *testing.T) {
+	server, client := pipePair(t)
+	part1 := []byte("*3\r\n$3\r\nSET\r\n$3\r\nfoo")
+	part2 := []byte("\r\n$3\r\nbar\r\n")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = client.Write(part1)
+		// Tight enough that we stay inside the settle window.
+		time.Sleep(5 * time.Millisecond)
+		_, _ = client.Write(part2)
+	}()
+
+	buf, err := readBinaryFrame(server, 2*time.Second)
+	wg.Wait()
+	assert.NoError(t, err)
+	assert.Equal(t, append(part1, part2...), buf, "multi-write burst should merge into one frame")
+}
+
+func TestReadBinaryFrame_StopsOnSettleWindow(t *testing.T) {
+	// Write one frame, then stop writing. The reader should return promptly
+	// (after the settle window), not wait for the session deadline.
+	server, client := pipePair(t)
+	frame := []byte("*1\r\n$4\r\nPING\r\n")
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		_, _ = client.Write(frame)
+	}()
+
+	start := time.Now()
+	buf, err := readBinaryFrame(server, 5*time.Second)
+	elapsed := time.Since(start)
+
+	<-writerDone
+	assert.NoError(t, err)
+	assert.Equal(t, frame, buf)
+	// 5-second session deadline but settle window should return in ~50 ms.
+	// Generous 500 ms upper bound to avoid flakes on loaded CI.
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"reader should return via settle window, not session deadline")
+}
+
+func TestReadBinaryFrame_ClosedConnectionReturnsError(t *testing.T) {
+	// net.Pipe returns its own "closed pipe" error; real net.TCPConn
+	// returns io.EOF. Accept either — we just need "no data + error".
+	server, client := pipePair(t)
+	_ = client.Close()
+	buf, err := readBinaryFrame(server, 500*time.Millisecond)
+	assert.Error(t, err)
+	assert.Empty(t, buf)
+}
+
+// Mock tracer for handler test.
+type captureTracer struct {
+	mu     sync.Mutex
+	events []tracer.Event
+}
+
+func (c *captureTracer) TraceEvent(e tracer.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+}
+
+func (c *captureTracer) snapshot() []tracer.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]tracer.Event, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+// ─── handleBinarySafeConnection — full round-trip ────────────────────
+
+func TestHandleBinarySafe_RESPPingReturnsPong(t *testing.T) {
+	server, client := pipePair(t)
+	cap := &captureTracer{}
+
+	pingRegex := regexp.MustCompile("^(?i)PING$")
+	cfg := parser.BeelzebubServiceConfiguration{
+		BinarySafe:             true,
+		DeadlineTimeoutSeconds: 2,
+		Commands: []parser.Command{
+			{
+				RegexStr:    "^(?i)PING$",
+				Regex:       pingRegex,
+				Handler:     "PONG",
+				ReplyFormat: "redis-simple",
+				Name:        "ping",
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleBinarySafeConnection(server, cfg, cap)
+		close(done)
+	}()
+
+	// Send one RESP2 PING.
+	_, err := client.Write([]byte("*1\r\n$4\r\nPING\r\n"))
+	assert.NoError(t, err)
+
+	// Read the reply.
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	reply := make([]byte, 64)
+	n, _ := client.Read(reply)
+	assert.Equal(t, "+PONG\r\n", string(reply[:n]))
+
+	_ = client.Close()
+	<-done
+
+	events := cap.snapshot()
+	if assert.Len(t, events, 1, "expect one Interaction event per matched command") {
+		e := events[0]
+		assert.Equal(t, "TCP binary-safe interaction", e.Msg)
+		assert.Equal(t, "PING", e.Command)
+		assert.Equal(t, `*1\x0d\x0a$4\x0d\x0aPING\x0d\x0a`, e.CommandRaw)
+		assert.Equal(t, "PONG", e.CommandOutput)
+		assert.Equal(t, "ping", e.Handler)
+		assert.Equal(t, "TCP", e.Protocol)
+		assert.Equal(t, tracer.Interaction.String(), e.Status)
+	}
+}
+
+func TestHandleBinarySafe_FallbackOnNoMatch(t *testing.T) {
+	server, client := pipePair(t)
+	cap := &captureTracer{}
+
+	cfg := parser.BeelzebubServiceConfiguration{
+		BinarySafe:             true,
+		DeadlineTimeoutSeconds: 2,
+		FallbackCommand: parser.Command{
+			Handler:     "ERR unknown command",
+			ReplyFormat: "redis-error",
+			Name:        "catch_all",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleBinarySafeConnection(server, cfg, cap)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("*1\r\n$6\r\nFOOBAR\r\n"))
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	reply := make([]byte, 64)
+	n, _ := client.Read(reply)
+	assert.Equal(t, "-ERR unknown command\r\n", string(reply[:n]))
+
+	_ = client.Close()
+	<-done
+
+	events := cap.snapshot()
+	if assert.Len(t, events, 1) {
+		assert.Equal(t, "catch_all", events[0].Handler)
+		assert.Equal(t, "FOOBAR", events[0].Command)
+	}
+}
+
+func TestHandleBinarySafe_MultipleCommandsOnOneConnection(t *testing.T) {
+	// Redis clients reuse connections; each frame must be answered in turn.
+	server, client := pipePair(t)
+	cap := &captureTracer{}
+
+	pingRegex := regexp.MustCompile("^(?i)PING$")
+	infoRegex := regexp.MustCompile("^(?i)INFO$")
+	cfg := parser.BeelzebubServiceConfiguration{
+		BinarySafe:             true,
+		DeadlineTimeoutSeconds: 2,
+		Commands: []parser.Command{
+			{RegexStr: "^(?i)PING$", Regex: pingRegex, Handler: "PONG", ReplyFormat: "redis-simple", Name: "ping"},
+			{RegexStr: "^(?i)INFO$", Regex: infoRegex, Handler: "redis_version:7.2.4", ReplyFormat: "redis-bulk", Name: "info"},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleBinarySafeConnection(server, cfg, cap)
+		close(done)
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	_, _ = client.Write([]byte("*1\r\n$4\r\nPING\r\n"))
+	reply1 := make([]byte, 64)
+	n1, _ := client.Read(reply1)
+	assert.Equal(t, "+PONG\r\n", string(reply1[:n1]))
+
+	_, _ = client.Write([]byte("*1\r\n$4\r\nINFO\r\n"))
+	reply2 := make([]byte, 64)
+	n2, _ := client.Read(reply2)
+	assert.Equal(t, "$19\r\nredis_version:7.2.4\r\n", string(reply2[:n2]))
+
+	_ = client.Close()
+	<-done
+
+	events := cap.snapshot()
+	if assert.Len(t, events, 2) {
+		assert.Equal(t, "PING", events[0].Command)
+		assert.Equal(t, "INFO", events[1].Command)
+	}
+}
+
+func TestHandleBinarySafe_BannerWrittenByteExact(t *testing.T) {
+	// Byte-exact banner: no appended newline, no mangling.
+	server, client := pipePair(t)
+	cap := &captureTracer{}
+
+	cfg := parser.BeelzebubServiceConfiguration{
+		BinarySafe:             true,
+		DeadlineTimeoutSeconds: 1,
+		Banner:                 "\x00\x11\x22\x33raw-banner",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleBinarySafeConnection(server, cfg, cap)
+		close(done)
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(1 * time.Second))
+	got := make([]byte, 64)
+	n, _ := client.Read(got)
+	assert.Equal(t, []byte("\x00\x11\x22\x33raw-banner"), got[:n])
+
+	_ = client.Close()
+	<-done
+}
+
+// ─── bytesIndexCRLF helpers ──────────────────────────────────────────
+
+func TestBytesIndexCRLF(t *testing.T) {
+	assert.Equal(t, 3, bytesIndexCRLF([]byte("abc\r\ndef")))
+	assert.Equal(t, -1, bytesIndexCRLF([]byte("no-crlf-here")))
+	assert.Equal(t, -1, bytesIndexCRLF([]byte("")))
+	assert.Equal(t, 0, bytesIndexCRLF([]byte("\r\nabc")))
+}
+
+func TestBytesIndexCRLFFrom(t *testing.T) {
+	b := []byte("abc\r\ndef\r\nghi")
+	assert.Equal(t, 3, bytesIndexCRLFFrom(b, 0))
+	assert.Equal(t, 8, bytesIndexCRLFFrom(b, 5))
+	assert.Equal(t, -1, bytesIndexCRLFFrom(b, 10))
+	assert.Equal(t, 3, bytesIndexCRLFFrom(b, -1), "negative offset should be treated as 0")
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -38,6 +38,12 @@ type Event struct {
 	SourcePort      string
 	TLSServerName   string
 	Handler         string
+	// CommandRaw is a hex-escaped representation of the raw bytes the
+	// client sent, populated only when the strategy captures a binary
+	// frame that would otherwise be mangled by a string conversion
+	// (e.g. RESP2 / LDAP BER / PostgreSQL startup). Omitted from JSON
+	// when empty, so existing events keep their wire shape.
+	CommandRaw string `json:"CommandRaw,omitempty"`
 }
 
 type (


### PR DESCRIPTION
## Summary

The default TCP strategy reads up to 1024 bytes once, traces the result, and closes. That works for banner probes but fails for any binary wire protocol: RESP2 (`*1\r\n$4\r\nPING\r\n`) arrives multi-line; a regex against the line-mangled read never matches and the server writes zero bytes back, leaving the client hanging until its timeout.

This PR adds an opt-in alternative path selected by `binarySafe: true` in the service YAML. When enabled, the strategy:

1. **Preserves every byte** via `readBinaryFrame` — no string conversion, no `\r\n` stripping, no UTF-8 replacement. A short settle window (50 ms) detects end-of-frame for protocols that pack multiple lines per request.
2. **Extracts a regex-friendly logical command** via `decodeProtocolCommand`, auto-detecting RESP2 arrays, RESP2 simple/error/integer/bulk-header, plain ASCII, and binary noise. The matcher sees `"PING"` even when the wire sent `*1\r\n$4\r\nPING\r\n`.
3. **Frames replies on-wire** via `encodeReply` and a new `ReplyFormat` field on `Command`:

   | ReplyFormat      | Wire output                                       |
   |------------------|---------------------------------------------------|
   | (empty)          | `<handler>\r\n` — legacy plaintext (default)      |
   | `redis-simple`   | `+<handler>\r\n`                                  |
   | `redis-integer`  | `:<handler>\r\n`                                  |
   | `redis-error`    | `-<handler>\r\n`                                  |
   | `redis-bulk`     | `$<len>\r\n<handler>\r\n` (length auto-computed)  |
   | `redis-nil-bulk` | `$-1\r\n`                                         |
   | `redis-array`    | `*<n>\r\n` + per-entry bulk encoding of `ReplyBulks` |
   | `redis-raw`      | `<handler>` verbatim — escape hatch for nested shapes |

   Unknown values log a warning and fall back to plaintext so a YAML typo does not silently drop traffic.
4. **Captures forensic bytes** via a new `CommandRaw` trace-event field — a hex-escaped rendering of the exact client bytes (e.g. `*1\x0d\x0a$4\x0d\x0aPING\x0d\x0a`). Non-UTF-8 bytes like the LDAP CONTEXT 0 IMPLICIT tag (`0x80`) or PostgreSQL SSLRequest magic (`0xd2`) survive inspection rather than being silently replaced with `U+FFFD`.

RESP2 encodings follow the [Redis protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec/).

## Changes

- **`protocols/strategies/TCP/tcp.go`** — three-line dispatch. When `servConf.BinarySafe` is true, hand off to `handleBinarySafeConnection`; otherwise the existing banner-and-read code path runs unchanged.
- **`protocols/strategies/TCP/tcp_binarysafe.go`** (new) — `handleBinarySafeConnection`, `readBinaryFrame`, `decodeProtocolCommand`, `decodeRESPArray`, `encodeReply`, `hexEscapeNonPrintable`, and supporting helpers. Hand-written; no new dependencies.
- **`parser/configurations_parser.go`** — adds `BinarySafe bool` to `BeelzebubServiceConfiguration`, `ReplyFormat string` and `ReplyBulks []string` to `Command`. All three carry `json:",omitempty"`, so `HashCode()` stays byte-stable for configs that don't use them.
- **`tracer/tracer.go`** — adds `CommandRaw string` with `json:",omitempty"`. Existing events keep their JSON shape.
- **`configurations/services/tcp-6379-redis.yaml`** (new) — reference Redis 7.2.4 config using `binarySafe: true` with `HELLO`/`CLIENT SETINFO`/`PING`/`AUTH`/`INFO`/`COMMAND`/catch-all handlers.

## Backward compatibility

- `binarySafe: false` (the default) preserves the existing TCP strategy exactly. Every existing yaml — `tcp-3306.yaml` and any operator's custom configs — continues to behave as before.
- `ReplyFormat: ""` (the default) preserves the legacy `handler + "\r\n"` reply.
- `CommandRaw`, `BinarySafe`, `ReplyFormat`, and `ReplyBulks` all use `json:",omitempty"` so `BeelzebubServiceConfiguration.HashCode()` produces the same digest for every existing config. Verified by the new `TestBinarySafeReplyFormatHashCodeStability` (the stored hash `528e52a4b7…` stays unchanged).

## Tests

28 new unit tests in `protocols/strategies/TCP/tcp_binarysafe_test.go`, covering:

- `decodeProtocolCommand` — RESP2 array (PING / SET / INFO / CLIENT LIST / lowercase), RESP2 simple / error / integer / bulk-header (table-driven), plain ASCII, binary noise, empty input, truncated RESP, malformed RESP, zero-arg-count, huge argc rejection, bulk-length overrun.
- `hexEscapeNonPrintable` — printable ASCII, CRLF, null byte, backslash self-escape, high byte (`0x80`) preservation.
- `isMostlyPrintable` — boundary cases on the 90% heuristic.
- `encodeReply` — every declared `ReplyFormat` plus the unknown-format fallback and the legacy empty-value suppression.
- `readBinaryFrame` — single write, burst across writes, settle-window triggers promptly, closed connection returns an error.
- `handleBinarySafeConnection` — full round-trip with RESP2 PING → `+PONG\r\n`, fallback on no match, multiple commands on one connection, byte-exact banner.
- Hash-code stability in `parser/configurations_parser_test.go`.

All pass with `go test -race ./...`. Full suite also passes.

## Verified against real clients

| Client                                            | Result                                                      |
|---------------------------------------------------|-------------------------------------------------------------|
| `redis-cli` 7.0.15                                | PING → PONG; INFO → bulk; AUTH → `-ERR`; COMMAND → array; unknown → `-ERR unknown command` |
| `redis-py` 7.4.0 (Django / Celery / rq)           | `r.ping() → True`; `r.info('server') → dict`; `r.execute_command('FOOBAR')` raises `ResponseError` |
| `go-redis/v9` 9.17.0 with `Protocol: 2`           | `PING → PONG`; `INFO → full body`; `FOOBAR → ERR unknown command` |

## Out of scope

- `HELLO 3` / RESP3 negotiation. The shipped reference config returns `-NOPROTO unsupported protocol version`, which most clients tolerate by falling back to RESP2 (go-redis needs an explicit `Protocol: 2` option — a `redis-map` encoder for a real HELLO-2 success response is the natural follow-up).
- Binary protocol handlers (LDAP BER, PostgreSQL wire, MySQL handshake). Those use the same primitives but belong in their own PRs.


 All Submissions:

* [ x] Have you followed the guidelines in our Contributing document?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ x] Does your submission pass tests?
2. [ x] Have you lint your code locally before submission?

### Changes to Core Features:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you written new tests for your core changes, as applicable?
* [ x] Have you successfully run tests with your changes locally?
