### PR TITLE
Feat: add beelzebub validate CLI command for static configuration checks

### DIFF
--- a/cli/validate.go
+++ b/cli/validate.go
@@ -2,11 +2,16 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	_ "github.com/beelzebub-labs/beelzebub/v3/internal/protocols/strategies/HTTP"
+	_ "github.com/beelzebub-labs/beelzebub/v3/internal/protocols/strategies/MCP"
+	_ "github.com/beelzebub-labs/beelzebub/v3/internal/protocols/strategies/SSH"
+	_ "github.com/beelzebub-labs/beelzebub/v3/internal/protocols/strategies/TCP"
+	_ "github.com/beelzebub-labs/beelzebub/v3/internal/protocols/strategies/TELNET"
 )
 
 var (
@@ -17,7 +22,7 @@ var (
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate configuration files without starting services",
-	Long:  "Parse and validate core and service YAML configurations, reporting any errors.",
+	Long:  "Parse and validate core and service YAML configurations, reporting any errors and warnings.",
 	RunE:  validateConfigurations,
 }
 
@@ -26,79 +31,38 @@ func init() {
 	validateCmd.Flags().StringVarP(&validateConfServices, "conf-services", "s", "./configurations/services/", "Path to services configuration directory")
 }
 
-var knownProtocols = map[string]bool{
-	"http": true, "ssh": true, "tcp": true, "telnet": true, "mcp": true,
-}
-
 func validateConfigurations(_ *cobra.Command, _ []string) error {
-	// suppress logrus noise during validation
 	log.SetLevel(log.ErrorLevel)
 
 	p := parser.Init(validateConfCore, validateConfServices)
 
-	coreConf, err := p.ReadConfigurationsCore()
-	if err != nil {
-		return fmt.Errorf("core config: %w", err)
-	}
-
-	printSection("Core configuration", validateConfCore)
-	printField("Prometheus", formatOptional(coreConf.Core.Prometheus.Port+coreConf.Core.Prometheus.Path))
-	printField("RabbitMQ", formatBool(coreConf.Core.Tracings.RabbitMQ.Enabled))
-	printField("Beelzebub Cloud", formatBool(coreConf.Core.BeelzebubCloud.Enabled))
-
-	services, err := p.ReadConfigurationsServices()
+	services, parseIssues, err := p.ReadConfigurationsServicesForValidation()
 	if err != nil {
 		return fmt.Errorf("services config: %w", err)
 	}
 
-	fmt.Println()
-	printSection("Services", fmt.Sprintf("%s (%d found)", validateConfServices, len(services)))
+	serviceResult := parser.Validate(services, parseIssues)
 
-	for i, svc := range services {
-		if !knownProtocols[svc.Protocol] {
-			return fmt.Errorf("service[%d] %q: unknown protocol %q", i+1, svc.Address, svc.Protocol)
-		}
+	coreConf, err := p.ReadConfigurationsCore()
+	if err != nil {
+		coreConf = &parser.BeelzebubCoreConfigurations{}
+	}
+	coreResult := parser.ValidateCore(coreConf, validateConfCore)
 
-		extras := []string{}
-		if svc.Plugin.LLMProvider != "" {
-			extras = append(extras, fmt.Sprintf("plugin:%s/%s", svc.Plugin.LLMProvider, svc.Plugin.LLMModel))
-		}
-		if svc.Plugin.RateLimitEnabled {
-			extras = append(extras, "rate-limited")
-		}
-		suffix := ""
-		if len(extras) > 0 {
-			suffix = "  [" + strings.Join(extras, ", ") + "]"
-		}
-		desc := svc.Description
-		if desc == "" {
-			desc = svc.ServerName
-		}
-		fmt.Printf("  [%d] %-7s %-22s %s%s\n", i+1, svc.Protocol, svc.Address, desc, suffix)
+	combined := parser.ValidateResult{
+		Results:       append(serviceResult.Results, coreResult.Results...),
+		TotalErrors:   serviceResult.TotalErrors + coreResult.TotalErrors,
+		TotalWarnings: serviceResult.TotalWarnings + coreResult.TotalWarnings,
 	}
 
-	fmt.Println("\nAll configurations are valid.")
+	fmt.Printf("Validating services from %s\n", validateConfServices)
+	fmt.Printf("Validating core from %s\n\n", validateConfCore)
+
+	combined.Print()
+
+	if combined.ExitCode() != 0 {
+		return fmt.Errorf("validation failed with %d error(s)", combined.TotalErrors)
+	}
+
 	return nil
-}
-
-func printSection(title, detail string) {
-	fmt.Printf("%s: %s\n", title, detail)
-}
-
-func printField(name, value string) {
-	fmt.Printf("  %-18s %s\n", name+":", value)
-}
-
-func formatBool(v bool) string {
-	if v {
-		return "enabled"
-	}
-	return "disabled"
-}
-
-func formatOptional(s string) string {
-	if s == "" {
-		return "(not set)"
-	}
-	return s
 }

--- a/internal/parser/configurations_parser.go
+++ b/internal/parser/configurations_parser.go
@@ -70,6 +70,7 @@ type Plugin struct {
 
 // BeelzebubServiceConfiguration is the struct that contains the configurations of the honeypot service
 type BeelzebubServiceConfiguration struct {
+	Filename               string    `yaml:"-" json:"-"`
 	ApiVersion             string    `yaml:"apiVersion"`
 	Protocol               string    `yaml:"protocol"`
 	Address                string    `yaml:"address"`
@@ -275,6 +276,7 @@ func (bp configurationsParser) ReadConfigurationsServices() ([]BeelzebubServiceC
 			return nil, fmt.Errorf("in file %s: invalid regex: %v", filePath, err)
 		}
 
+		beelzebubServiceConfiguration.Filename = servicesName
 		servicesConfiguration = append(servicesConfiguration, *beelzebubServiceConfiguration)
 	}
 
@@ -291,6 +293,7 @@ func parseServicesFromEnv(jsonStr string) ([]BeelzebubServiceConfiguration, erro
 
 	for i := range servicesConfiguration {
 		svc := &servicesConfiguration[i]
+		servicesConfiguration[i].Filename = "<env:BEELZEBUB_SERVICES_CONFIG>"
 
 		if svc.Plugin.RateLimitEnabled {
 			if svc.Plugin.RateLimitRequests <= 0 || svc.Plugin.RateLimitWindowSeconds <= 0 {
@@ -304,6 +307,89 @@ func parseServicesFromEnv(jsonStr string) ([]BeelzebubServiceConfiguration, erro
 	}
 
 	return servicesConfiguration, nil
+}
+
+func (bp configurationsParser) ReadConfigurationsServicesForValidation() ([]BeelzebubServiceConfiguration, []ValidationIssue, error) {
+	if envConfig := os.Getenv("BEELZEBUB_SERVICES_CONFIG"); envConfig != "" {
+		return parseServicesFromEnvForValidation(envConfig)
+	}
+
+	services, err := bp.gelAllFilesNameByDirNameDependency(bp.configurationsServicesDirectory)
+	if err != nil {
+		if isNotFound(err) {
+			return []BeelzebubServiceConfiguration{}, nil, nil
+		}
+		return nil, nil, fmt.Errorf("in directory %s: %v", bp.configurationsServicesDirectory, err)
+	}
+
+	var servicesConfiguration []BeelzebubServiceConfiguration
+	var issues []ValidationIssue
+
+	for _, servicesName := range services {
+		filePath := filepath.Join(bp.configurationsServicesDirectory, servicesName)
+		buf, err := bp.readFileBytesByFilePathDependency(filePath)
+		if err != nil {
+			issues = append(issues, ValidationIssue{Level: LevelError, Message: err.Error(), Filename: servicesName})
+			continue
+		}
+
+		beelzebubServiceConfiguration := &BeelzebubServiceConfiguration{}
+		err = yaml.Unmarshal(buf, beelzebubServiceConfiguration)
+		if err != nil {
+			issues = append(issues, ValidationIssue{Level: LevelError, Message: err.Error(), Filename: servicesName})
+			continue
+		}
+
+		beelzebubServiceConfiguration.Filename = servicesName
+
+		if beelzebubServiceConfiguration.Plugin.RateLimitEnabled {
+			if beelzebubServiceConfiguration.Plugin.RateLimitRequests <= 0 ||
+				beelzebubServiceConfiguration.Plugin.RateLimitWindowSeconds <= 0 {
+				issues = append(issues, ValidationIssue{Level: LevelError, Message: "invalid rate limiting config: rateLimitRequests and rateLimitWindowSeconds must be > 0", Filename: servicesName})
+				continue
+			}
+		}
+
+		if err := beelzebubServiceConfiguration.CompileCommandRegex(); err != nil {
+			issues = append(issues, ValidationIssue{Level: LevelError, Message: fmt.Sprintf("invalid regex: %v", err), Filename: servicesName})
+			continue
+		}
+
+		servicesConfiguration = append(servicesConfiguration, *beelzebubServiceConfiguration)
+	}
+
+	return servicesConfiguration, issues, nil
+}
+
+func parseServicesFromEnvForValidation(jsonStr string) ([]BeelzebubServiceConfiguration, []ValidationIssue, error) {
+	var servicesConfiguration []BeelzebubServiceConfiguration
+	if err := json.Unmarshal([]byte(jsonStr), &servicesConfiguration); err != nil {
+		return nil, nil, fmt.Errorf("invalid BEELZEBUB_SERVICES_CONFIG: %v", err)
+	}
+
+	var issues []ValidationIssue
+	var validServices []BeelzebubServiceConfiguration
+
+	for i := range servicesConfiguration {
+		svc := &servicesConfiguration[i]
+		servicesConfiguration[i].Filename = "<env:BEELZEBUB_SERVICES_CONFIG>"
+
+		if svc.Plugin.RateLimitEnabled {
+			if svc.Plugin.RateLimitRequests <= 0 || svc.Plugin.RateLimitWindowSeconds <= 0 {
+				issues = append(issues, ValidationIssue{Level: LevelError, Message: "invalid rate limiting config: rateLimitRequests and rateLimitWindowSeconds must be > 0", Filename: svc.Filename})
+				continue
+			}
+		}
+
+		if err := svc.CompileCommandRegex(); err != nil {
+			issues = append(issues, ValidationIssue{Level: LevelError, Message: fmt.Sprintf("invalid regex: %v", err), Filename: svc.Filename})
+			continue
+		}
+
+		validServices = append(validServices, *svc)
+	}
+
+	return validServices, issues, nil
 }
 
 // CompileCommandRegex is the method that compiles the regular expression for each configured Command.

--- a/internal/parser/configurations_parser_test.go
+++ b/internal/parser/configurations_parser_test.go
@@ -729,3 +729,127 @@ func TestHashCode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, hash, hash3)
 }
+
+func mockReadDirWithFilename(dirPath string) ([]string, error) {
+	return []string{"test-service.yaml"}, nil
+}
+
+func mockReadDirMultipleFiles(dirPath string) ([]string, error) {
+	return []string{"valid.yaml", "invalid-yaml.yaml", "invalid-regex.yaml"}, nil
+}
+
+func mockReadFileBytesForValidation(filePath string) ([]byte, error) {
+	switch filePath {
+	case "valid.yaml":
+		return mockReadfilebytesBeelzebubServiceConfiguration(filePath)
+	case "invalid-yaml.yaml":
+		return []byte(`{{}`), nil
+	case "invalid-regex.yaml":
+		return []byte(`
+apiVersion: "v1"
+protocol: "http"
+address: ":8080"
+commands:
+  - regex: "[invalid"
+    handler: "login"
+`), nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func TestReadConfigurationsServicesFilenameIsSet(t *testing.T) {
+	os.Unsetenv("BEELZEBUB_SERVICES_CONFIG")
+
+	configurationsParser := Init("", "")
+	configurationsParser.readFileBytesByFilePathDependency = mockReadfilebytesBeelzebubServiceConfiguration
+	configurationsParser.gelAllFilesNameByDirNameDependency = mockReadDirWithFilename
+
+	services, err := configurationsParser.ReadConfigurationsServices()
+	assert.Nil(t, err)
+	assert.Len(t, services, 1)
+	assert.Equal(t, "test-service.yaml", services[0].Filename)
+}
+
+func TestReadConfigurationsServicesForValidationNoErrors(t *testing.T) {
+	os.Unsetenv("BEELZEBUB_SERVICES_CONFIG")
+
+	configurationsParser := Init("", "")
+	configurationsParser.readFileBytesByFilePathDependency = mockReadfilebytesBeelzebubServiceConfiguration
+	configurationsParser.gelAllFilesNameByDirNameDependency = mockReadDirWithFilename
+
+	services, issues, err := configurationsParser.ReadConfigurationsServicesForValidation()
+	assert.Nil(t, err)
+	assert.Len(t, services, 1)
+	assert.Empty(t, issues)
+	assert.Equal(t, "test-service.yaml", services[0].Filename)
+}
+
+func TestReadConfigurationsServicesForValidationWithErrors(t *testing.T) {
+	os.Unsetenv("BEELZEBUB_SERVICES_CONFIG")
+
+	configurationsParser := Init("", "")
+	configurationsParser.readFileBytesByFilePathDependency = mockReadFileBytesForValidation
+	configurationsParser.gelAllFilesNameByDirNameDependency = mockReadDirMultipleFiles
+
+	services, issues, err := configurationsParser.ReadConfigurationsServicesForValidation()
+	assert.Nil(t, err)
+	assert.Len(t, services, 1)
+	assert.Len(t, issues, 2)
+	assert.Equal(t, "valid.yaml", services[0].Filename)
+	assert.Equal(t, "invalid-yaml.yaml", issues[0].Filename)
+	assert.Equal(t, LevelError, issues[0].Level)
+	assert.Equal(t, "invalid-regex.yaml", issues[1].Filename)
+	assert.Equal(t, "error", issues[1].Level)
+}
+
+func TestReadConfigurationsServicesForValidationFromEnv(t *testing.T) {
+	t.Setenv("BEELZEBUB_SERVICES_CONFIG", `[{"apiVersion":"v1","protocol":"ssh","address":":2222"}]`)
+
+	configurationsParser := Init("", "")
+
+	services, issues, err := configurationsParser.ReadConfigurationsServicesForValidation()
+	assert.Nil(t, err)
+	assert.Len(t, services, 1)
+	assert.Empty(t, issues)
+	assert.Equal(t, "<env:BEELZEBUB_SERVICES_CONFIG>", services[0].Filename)
+	assert.Equal(t, "ssh", services[0].Protocol)
+}
+
+func TestReadConfigurationsServicesForValidationWithRateLimitError(t *testing.T) {
+	os.Unsetenv("BEELZEBUB_SERVICES_CONFIG")
+
+	configurationsParser := Init("", "")
+	configurationsParser.readFileBytesByFilePathDependency = func(filePath string) ([]byte, error) {
+		return []byte(`
+apiVersion: "v1"
+protocol: "http"
+address: ":8080"
+commands:
+  - regex: "^(.+)$"
+plugin:
+  rateLimitEnabled: true
+  rateLimitRequests: 0
+  rateLimitWindowSeconds: 0
+`), nil
+	}
+	configurationsParser.gelAllFilesNameByDirNameDependency = mockReadDirWithFilename
+
+	services, issues, err := configurationsParser.ReadConfigurationsServicesForValidation()
+	assert.Nil(t, err)
+	assert.Empty(t, services)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "invalid rate limiting config")
+}
+
+func TestReadConfigurationsServicesForValidationFromEnvInvalidJSON(t *testing.T) {
+	t.Setenv("BEELZEBUB_SERVICES_CONFIG", `{invalid}`)
+
+	configurationsParser := Init("", "")
+
+	services, issues, err := configurationsParser.ReadConfigurationsServicesForValidation()
+	assert.Error(t, err)
+	assert.Nil(t, services)
+	assert.Nil(t, issues)
+	assert.Contains(t, err.Error(), "invalid BEELZEBUB_SERVICES_CONFIG")
+}

--- a/internal/parser/validator.go
+++ b/internal/parser/validator.go
@@ -1,0 +1,335 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const (
+	LevelError   = "error"
+	LevelWarning = "warning"
+)
+
+type ValidationIssue struct {
+	Level    string
+	Message  string
+	Filename string
+}
+
+type ValidationResult struct {
+	Filename string
+	Issues   []ValidationIssue
+}
+
+type ValidateResult struct {
+	Results       []ValidationResult
+	TotalErrors   int
+	TotalWarnings int
+}
+
+type ServiceValidator interface {
+	Name() string
+	Validate(config BeelzebubServiceConfiguration) []ValidationIssue
+}
+
+var serviceValidators []ServiceValidator
+
+func RegisterServiceValidator(v ServiceValidator) {
+	serviceValidators = append(serviceValidators, v)
+}
+
+func ResetServiceValidators() {
+	serviceValidators = nil
+}
+
+var validProtocols = []string{"http", "ssh", "tcp", "mcp", "telnet"}
+
+var validCommandPlugins = []string{"", "LLMHoneypot", "MazeHoneypot"}
+
+var validCommandPluginsDisplay = []string{"(none)", "LLMHoneypot", "MazeHoneypot"}
+
+func Validate(services []BeelzebubServiceConfiguration, parseIssues []ValidationIssue) ValidateResult {
+	resultMap := make(map[string]*ValidationResult)
+
+	for _, issue := range parseIssues {
+		r, ok := resultMap[issue.Filename]
+		if !ok {
+			r = &ValidationResult{Filename: issue.Filename}
+			resultMap[issue.Filename] = r
+		}
+		r.Issues = append(r.Issues, issue)
+	}
+
+	for i := range services {
+		filename := services[i].Filename
+		r, ok := resultMap[filename]
+		if !ok {
+			r = &ValidationResult{Filename: filename}
+			resultMap[filename] = r
+		}
+
+		protocol := services[i].Protocol
+		if !slices.Contains(validProtocols, protocol) {
+			r.Issues = append(r.Issues, ValidationIssue{
+				Level:   LevelError,
+				Message: fmt.Sprintf("invalid protocol %q, valid: %s", protocol, strings.Join(validProtocols, ", ")),
+			})
+		}
+
+		address := strings.TrimSpace(services[i].Address)
+		if address == "" {
+			r.Issues = append(r.Issues, ValidationIssue{
+				Level:   LevelError,
+				Message: "address is empty",
+			})
+		} else if !strings.Contains(address, "/") {
+			lastColon := strings.LastIndex(address, ":")
+			if lastColon == -1 {
+				r.Issues = append(r.Issues, ValidationIssue{
+					Level:   LevelWarning,
+					Message: fmt.Sprintf("address %q has invalid port format or port out of range (1-65535)", address),
+				})
+			} else {
+				portStr := address[lastColon+1:]
+				port, err := strconv.Atoi(portStr)
+				if err != nil || port < 1 || port > 65535 {
+					r.Issues = append(r.Issues, ValidationIssue{
+						Level:   LevelWarning,
+						Message: fmt.Sprintf("address %q has invalid port format or port out of range (1-65535)", address),
+					})
+				}
+			}
+		}
+
+		for j, cmd := range services[i].Commands {
+			if cmd.RegexStr == "" {
+				r.Issues = append(r.Issues, ValidationIssue{
+					Level:   LevelError,
+					Message: fmt.Sprintf("command[%d] has empty regex", j),
+				})
+			}
+			if !slices.Contains(validCommandPlugins, cmd.Plugin) {
+				r.Issues = append(r.Issues, ValidationIssue{
+					Level:   LevelError,
+					Message: fmt.Sprintf("command[%d] has invalid plugin %q, valid: %s", j, cmd.Plugin, strings.Join(validCommandPluginsDisplay, ", ")),
+				})
+			}
+			if cmd.Handler == "" && cmd.Plugin == "" {
+				r.Issues = append(r.Issues, ValidationIssue{
+					Level:   LevelWarning,
+					Message: fmt.Sprintf("command[%d] has empty handler and no plugin — matched requests will produce no output", j),
+				})
+			}
+			for _, header := range cmd.Headers {
+				if !strings.Contains(header, ":") {
+					r.Issues = append(r.Issues, ValidationIssue{
+						Level:   LevelWarning,
+						Message: fmt.Sprintf("command[%d].headers has malformed entry (no colon): %q", j, header),
+					})
+				}
+			}
+		}
+
+		fb := services[i].FallbackCommand
+		if fb.Handler != "" || fb.Plugin != "" {
+			if fb.RegexStr != "" {
+				if _, err := regexp.Compile(fb.RegexStr); err != nil {
+					r.Issues = append(r.Issues, ValidationIssue{
+						Level:   LevelError,
+						Message: fmt.Sprintf("fallbackCommand has invalid regex: %v", err),
+					})
+				}
+			}
+			if !slices.Contains(validCommandPlugins, fb.Plugin) {
+				r.Issues = append(r.Issues, ValidationIssue{
+					Level:   LevelError,
+					Message: fmt.Sprintf("fallbackCommand has invalid plugin %q, valid: %s", fb.Plugin, strings.Join(validCommandPluginsDisplay, ", ")),
+				})
+			}
+		}
+
+		if services[i].Plugin.OpenAISecretKey != "" {
+			r.Issues = append(r.Issues, ValidationIssue{
+				Level:   LevelWarning,
+				Message: "openAISecretKey is set inline, consider using env var OPEN_AI_SECRET_KEY",
+			})
+		}
+
+		if services[i].DeadlineTimeoutSeconds == 0 && len(services[i].Commands) > 0 {
+			r.Issues = append(r.Issues, ValidationIssue{
+				Level:   LevelWarning,
+				Message: "deadlineTimeoutSeconds is not set, connections may be closed immediately",
+			})
+		}
+
+		for _, v := range serviceValidators {
+			issues := v.Validate(services[i])
+			r.Issues = append(r.Issues, issues...)
+		}
+	}
+
+	collisionMap := make(map[string][]int)
+	for i, svc := range services {
+		key := svc.Protocol + ":" + svc.Address
+		collisionMap[key] = append(collisionMap[key], i)
+	}
+
+	for _, indices := range collisionMap {
+		if len(indices) > 1 {
+			for _, idx := range indices {
+				svc := services[idx]
+				r := resultMap[svc.Filename]
+				r.Issues = append(r.Issues, ValidationIssue{
+					Level:   LevelError,
+					Message: fmt.Sprintf("address %s:%s is used by multiple services", svc.Protocol, svc.Address),
+				})
+			}
+		}
+	}
+
+	var results []ValidationResult
+	for _, r := range resultMap {
+		results = append(results, *r)
+	}
+
+	var totalErrors, totalWarnings int
+	for _, r := range results {
+		for _, issue := range r.Issues {
+			switch issue.Level {
+			case LevelError:
+				totalErrors++
+			case LevelWarning:
+				totalWarnings++
+			}
+		}
+	}
+
+	return ValidateResult{
+		Results:       results,
+		TotalErrors:   totalErrors,
+		TotalWarnings: totalWarnings,
+	}
+}
+
+func (r ValidateResult) Print() {
+	sort.Slice(r.Results, func(i, j int) bool {
+		return r.Results[i].Filename < r.Results[j].Filename
+	})
+
+	for _, result := range r.Results {
+		hasErrors := false
+		for _, issue := range result.Issues {
+			if issue.Level == LevelError {
+				hasErrors = true
+				break
+			}
+		}
+
+		if len(result.Issues) == 0 {
+			fmt.Printf("OK %s\n", result.Filename)
+		} else if hasErrors {
+			fmt.Printf("FAIL %s\n", result.Filename)
+			for _, issue := range result.Issues {
+				fmt.Printf("  %s: %s\n", strings.ToUpper(issue.Level), issue.Message)
+			}
+		} else {
+			fmt.Printf("WARN %s\n", result.Filename)
+			for _, issue := range result.Issues {
+				fmt.Printf("  %s: %s\n", strings.ToUpper(issue.Level), issue.Message)
+			}
+		}
+	}
+
+	fmt.Printf("\n%d errors, %d warnings\n", r.TotalErrors, r.TotalWarnings)
+}
+
+func (r ValidateResult) ExitCode() int {
+	if r.TotalErrors > 0 {
+		return 1
+	}
+	return 0
+}
+
+func ValidateCore(config *BeelzebubCoreConfigurations, filename string) ValidateResult {
+	var issues []ValidationIssue
+
+	if config.Core.Tracings.RabbitMQ.Enabled && config.Core.Tracings.RabbitMQ.URI == "" {
+		issues = append(issues, ValidationIssue{
+			Level:    LevelError,
+			Message:  "rabbitMQ is enabled but URI is empty",
+			Filename: filename,
+		})
+	}
+
+	if config.Core.BeelzebubCloud.Enabled {
+		if config.Core.BeelzebubCloud.URI == "" {
+			issues = append(issues, ValidationIssue{
+				Level:    LevelError,
+				Message:  "beelzebub-cloud is enabled but URI is empty",
+				Filename: filename,
+			})
+		}
+		if config.Core.BeelzebubCloud.AuthToken == "" {
+			issues = append(issues, ValidationIssue{
+				Level:    LevelError,
+				Message:  "beelzebub-cloud is enabled but auth-token is empty",
+				Filename: filename,
+			})
+		}
+	}
+
+	if config.Core.Prometheus != (Prometheus{}) {
+		if config.Core.Prometheus.Path == "" {
+			issues = append(issues, ValidationIssue{
+				Level:    LevelError,
+				Message:  "prometheus is configured but path is empty",
+				Filename: filename,
+			})
+		} else if !strings.HasPrefix(config.Core.Prometheus.Path, "/") {
+			issues = append(issues, ValidationIssue{
+				Level:    LevelError,
+				Message:  fmt.Sprintf("prometheus path %q must start with /", config.Core.Prometheus.Path),
+				Filename: filename,
+			})
+		}
+		if config.Core.Prometheus.Port == "" {
+			issues = append(issues, ValidationIssue{
+				Level:    LevelError,
+				Message:  "prometheus is configured but port is empty",
+				Filename: filename,
+			})
+		}
+	}
+
+	if config.Core.Logging.LogsPath != "" {
+		parentDir := filepath.Dir(config.Core.Logging.LogsPath)
+		if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+			issues = append(issues, ValidationIssue{
+				Level:    LevelWarning,
+				Message:  fmt.Sprintf("logs path %q: parent directory %q does not exist", config.Core.Logging.LogsPath, parentDir),
+				Filename: filename,
+			})
+		}
+	}
+
+	var totalErrors int
+	for _, issue := range issues {
+		if issue.Level == LevelError {
+			totalErrors++
+		}
+	}
+
+	return ValidateResult{
+		Results: []ValidationResult{
+			{Filename: filename, Issues: issues},
+		},
+		TotalErrors:   totalErrors,
+		TotalWarnings: len(issues) - totalErrors,
+	}
+}

--- a/internal/parser/validator_test.go
+++ b/internal/parser/validator_test.go
@@ -1,0 +1,713 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeService(filename, protocol, address string, commands []Command) BeelzebubServiceConfiguration {
+	return BeelzebubServiceConfiguration{
+		Filename: filename,
+		Protocol: protocol,
+		Address:  address,
+		Commands: commands,
+	}
+}
+
+func findIssues(result ValidateResult, filename string) []ValidationIssue {
+	for _, r := range result.Results {
+		if r.Filename == filename {
+			return r.Issues
+		}
+	}
+	return nil
+}
+
+func hasIssue(issues []ValidationIssue, level, message string) bool {
+	for _, issue := range issues {
+		if issue.Level == level && issue.Message == message {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateProtocol(t *testing.T) {
+	tests := []struct {
+		name      string
+		protocol  string
+		wantError bool
+		errorMsg  string
+	}{
+		{"missing protocol", "", true, `invalid protocol "", valid: http, ssh, tcp, mcp, telnet`},
+		{"invalid protocol ftp", "ftp", true, `invalid protocol "ftp", valid: http, ssh, tcp, mcp, telnet`},
+		{"valid http", "http", false, ""},
+		{"valid ssh", "ssh", false, ""},
+		{"valid tcp", "tcp", false, ""},
+		{"valid mcp", "mcp", false, ""},
+		{"valid telnet", "telnet", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", tt.protocol, ":8080", nil)
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantError {
+				assert.True(t, hasIssue(issues, LevelError, tt.errorMsg))
+			} else {
+				for _, issue := range issues {
+					assert.NotContains(t, issue.Message, "invalid protocol")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		address   string
+		wantError bool
+	}{
+		{"empty address", "", true},
+		{"whitespace-only address", "   ", true},
+		{"valid address", ":8080", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", tt.address, nil)
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantError {
+				assert.True(t, hasIssue(issues, LevelError, "address is empty"))
+			} else {
+				assert.False(t, hasIssue(issues, LevelError, "address is empty"))
+			}
+		})
+	}
+}
+
+func TestValidateCommandRegexEmpty(t *testing.T) {
+	tests := []struct {
+		name      string
+		commands  []Command
+		wantError bool
+	}{
+		{
+			name:      "empty regex",
+			commands:  []Command{{RegexStr: ""}},
+			wantError: true,
+		},
+		{
+			name:      "non-empty regex",
+			commands:  []Command{{RegexStr: "wp-admin"}},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", tt.commands)
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantError {
+				assert.True(t, hasIssue(issues, LevelError, "command[0] has empty regex"))
+			} else {
+				assert.False(t, hasIssue(issues, LevelError, "command[0] has empty regex"))
+			}
+		})
+	}
+}
+
+func TestValidateCommandPluginInvalid(t *testing.T) {
+	tests := []struct {
+		name      string
+		plugin    string
+		wantError bool
+	}{
+		{"typo plugin name", "TypoPlugin", true},
+		{"empty plugin", "", false},
+		{"LLMHoneypot", "LLMHoneypot", false},
+		{"MazeHoneypot", "MazeHoneypot", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", []Command{
+				{RegexStr: "test", Plugin: tt.plugin},
+			})
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantError {
+				expectedMsg := fmt.Sprintf("command[0] has invalid plugin %q, valid: (none), LLMHoneypot, MazeHoneypot", tt.plugin)
+				assert.True(t, hasIssue(issues, LevelError, expectedMsg))
+			} else {
+				for _, issue := range issues {
+					assert.NotContains(t, issue.Message, "invalid plugin")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateFallbackCommand(t *testing.T) {
+	tests := []struct {
+		name          string
+		fallback      Command
+		wantRegexErr  bool
+		wantPluginErr bool
+	}{
+		{
+			name:          "empty handler and plugin",
+			fallback:      Command{},
+			wantRegexErr:  false,
+			wantPluginErr: false,
+		},
+		{
+			name:          "invalid plugin with valid regex",
+			fallback:      Command{Handler: "test", Plugin: "BadPlugin", RegexStr: ".*"},
+			wantRegexErr:  false,
+			wantPluginErr: true,
+		},
+		{
+			name:          "empty regex with valid plugin (fallback is catch-all, no regex needed)",
+			fallback:      Command{Handler: "test", Plugin: "LLMHoneypot"},
+			wantRegexErr:  false,
+			wantPluginErr: false,
+		},
+		{
+			name:          "invalid regex syntax in fallback",
+			fallback:      Command{Handler: "test", Plugin: "LLMHoneypot", RegexStr: "[invalid"},
+			wantRegexErr:  true,
+			wantPluginErr: false,
+		},
+		{
+			name:          "valid regex and valid plugin",
+			fallback:      Command{Handler: "test", Plugin: "MazeHoneypot", RegexStr: ".*"},
+			wantRegexErr:  false,
+			wantPluginErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", nil)
+			svc.FallbackCommand = tt.fallback
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantRegexErr {
+				assert.True(t, len(issues) > 0, "expected a regex error")
+				for _, issue := range issues {
+					if issue.Level == LevelError {
+						assert.Contains(t, issue.Message, "fallbackCommand has invalid regex")
+					}
+				}
+			} else {
+				for _, issue := range issues {
+					assert.NotContains(t, issue.Message, "fallbackCommand has invalid regex")
+				}
+			}
+
+			if tt.wantPluginErr {
+				expectedMsg := fmt.Sprintf("fallbackCommand has invalid plugin %q, valid: (none), LLMHoneypot, MazeHoneypot", tt.fallback.Plugin)
+				assert.True(t, hasIssue(issues, LevelError, expectedMsg))
+			} else {
+				for _, issue := range issues {
+					assert.NotContains(t, issue.Message, "fallbackCommand has invalid plugin")
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePortCollision(t *testing.T) {
+	tests := []struct {
+		name      string
+		services  []BeelzebubServiceConfiguration
+		wantError bool
+	}{
+		{
+			name: "same protocol and address",
+			services: []BeelzebubServiceConfiguration{
+				makeService("a.yaml", "http", ":8080", nil),
+				makeService("b.yaml", "http", ":8080", nil),
+			},
+			wantError: true,
+		},
+		{
+			name: "different addresses",
+			services: []BeelzebubServiceConfiguration{
+				makeService("a.yaml", "http", ":8080", nil),
+				makeService("b.yaml", "http", ":9090", nil),
+			},
+			wantError: false,
+		},
+		{
+			name: "same address different protocol",
+			services: []BeelzebubServiceConfiguration{
+				makeService("a.yaml", "http", ":8080", nil),
+				makeService("b.yaml", "ssh", ":8080", nil),
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Validate(tt.services, nil)
+
+			for _, svc := range tt.services {
+				issues := findIssues(result, svc.Filename)
+				expectedMsg := fmt.Sprintf("address %s:%s is used by multiple services", svc.Protocol, svc.Address)
+				if tt.wantError {
+					assert.True(t, hasIssue(issues, LevelError, expectedMsg))
+				} else {
+					assert.False(t, hasIssue(issues, LevelError, expectedMsg))
+				}
+			}
+		})
+	}
+}
+
+func TestValidateInlineSecretKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		secretKey string
+		wantWarn  bool
+	}{
+		{"non-empty secret key", "sk-12345", true},
+		{"empty secret key", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", nil)
+			svc.Plugin.OpenAISecretKey = tt.secretKey
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantWarn {
+				assert.True(t, hasIssue(issues, LevelWarning, "openAISecretKey is set inline, consider using env var OPEN_AI_SECRET_KEY"))
+			} else {
+				assert.False(t, hasIssue(issues, LevelWarning, "openAISecretKey is set inline"))
+			}
+		})
+	}
+}
+
+func TestValidateDeadlineTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  int
+		commands []Command
+		wantWarn bool
+	}{
+		{"zero with commands", 0, []Command{{RegexStr: "test"}}, true},
+		{"zero without commands", 0, nil, false},
+		{"non-zero with commands", 30, []Command{{RegexStr: "test"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", tt.commands)
+			svc.DeadlineTimeoutSeconds = tt.timeout
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantWarn {
+				assert.True(t, hasIssue(issues, LevelWarning, "deadlineTimeoutSeconds is not set, connections may be closed immediately"))
+			} else {
+				assert.False(t, hasIssue(issues, LevelWarning, "deadlineTimeoutSeconds is not set"))
+			}
+		})
+	}
+}
+
+func TestValidateWithParseIssues(t *testing.T) {
+	parseIssues := []ValidationIssue{
+		{Level: LevelError, Message: "YAML parse error: ...", Filename: "bad.yaml"},
+		{Level: LevelWarning, Message: "deprecated field", Filename: "old.yaml"},
+	}
+
+	result := Validate(nil, parseIssues)
+
+	assert.Len(t, result.Results, 2)
+	assert.Equal(t, 1, result.TotalErrors)
+	assert.Equal(t, 1, result.TotalWarnings)
+
+	badIssues := findIssues(result, "bad.yaml")
+	assert.True(t, hasIssue(badIssues, LevelError, "YAML parse error: ..."))
+
+	oldIssues := findIssues(result, "old.yaml")
+	assert.True(t, hasIssue(oldIssues, LevelWarning, "deprecated field"))
+}
+
+func TestValidatePrint(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ValidateResult
+		want   string
+	}{
+		{
+			name: "no issues",
+			result: ValidateResult{
+				Results: []ValidationResult{
+					{Filename: "service.yaml"},
+				},
+			},
+			want: "OK service.yaml\n\n0 errors, 0 warnings\n",
+		},
+		{
+			name: "errors",
+			result: ValidateResult{
+				Results: []ValidationResult{
+					{
+						Filename: "service.yaml",
+						Issues: []ValidationIssue{
+							{Level: LevelError, Message: "address is empty"},
+						},
+					},
+				},
+				TotalErrors: 1,
+			},
+			want: "FAIL service.yaml\n  ERROR: address is empty\n\n1 errors, 0 warnings\n",
+		},
+		{
+			name: "warnings only",
+			result: ValidateResult{
+				Results: []ValidationResult{
+					{
+						Filename: "service.yaml",
+						Issues: []ValidationIssue{
+							{Level: LevelWarning, Message: "some warning"},
+						},
+					},
+				},
+				TotalWarnings: 1,
+			},
+			want: "WARN service.yaml\n  WARNING: some warning\n\n0 errors, 1 warnings\n",
+		},
+		{
+			name: "sorted by filename",
+			result: ValidateResult{
+				Results: []ValidationResult{
+					{Filename: "z.yaml"},
+					{Filename: "a.yaml"},
+				},
+			},
+			want: "OK a.yaml\nOK z.yaml\n\n0 errors, 0 warnings\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			tt.result.Print()
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			got := buf.String()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   ValidateResult
+		wantCode int
+	}{
+		{"no errors", ValidateResult{TotalErrors: 0}, 0},
+		{"has errors", ValidateResult{TotalErrors: 3}, 1},
+		{"only warnings", ValidateResult{TotalErrors: 0, TotalWarnings: 5}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantCode, tt.result.ExitCode())
+		})
+	}
+}
+
+func TestValidateCore(t *testing.T) {
+	t.Run("all valid", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+	})
+
+	t.Run("custom filename", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Tracings.RabbitMQ.Enabled = true
+		result := ValidateCore(config, "/custom/path/core.yaml")
+		assert.Equal(t, 1, result.TotalErrors)
+		assert.Equal(t, "/custom/path/core.yaml", result.Results[0].Filename)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelError, "rabbitMQ is enabled but URI is empty"))
+	})
+
+	t.Run("rabbitmq enabled with empty URI", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Tracings.RabbitMQ.Enabled = true
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 1, result.TotalErrors)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelError, "rabbitMQ is enabled but URI is empty"))
+	})
+
+	t.Run("rabbitmq enabled with URI set", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Tracings.RabbitMQ.Enabled = true
+		config.Core.Tracings.RabbitMQ.URI = "amqp://localhost"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+	})
+
+	t.Run("beelzebub-cloud enabled with empty URI and auth-token", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.BeelzebubCloud.Enabled = true
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 2, result.TotalErrors)
+	})
+
+	t.Run("beelzebub-cloud enabled with URI but empty auth-token", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.BeelzebubCloud.Enabled = true
+		config.Core.BeelzebubCloud.URI = "https://api.example.com"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 1, result.TotalErrors)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelError, "beelzebub-cloud is enabled but auth-token is empty"))
+	})
+
+	t.Run("beelzebub-cloud fully configured", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.BeelzebubCloud.Enabled = true
+		config.Core.BeelzebubCloud.URI = "https://api.example.com"
+		config.Core.BeelzebubCloud.AuthToken = "token123"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+	})
+
+	t.Run("multiple core issues", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Tracings.RabbitMQ.Enabled = true
+		config.Core.BeelzebubCloud.Enabled = true
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 3, result.TotalErrors)
+	})
+
+	t.Run("prometheus all valid", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Prometheus.Path = "/metrics"
+		config.Core.Prometheus.Port = ":9090"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+		assert.Equal(t, 0, result.TotalWarnings)
+	})
+
+	t.Run("prometheus path empty", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Prometheus.Port = ":9090"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 1, result.TotalErrors)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelError, "prometheus is configured but path is empty"))
+	})
+
+	t.Run("prometheus path missing leading slash", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Prometheus.Path = "metrics"
+		config.Core.Prometheus.Port = ":9090"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 1, result.TotalErrors)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelError, "prometheus path \"metrics\" must start with /"))
+	})
+
+	t.Run("prometheus port empty", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Prometheus.Path = "/metrics"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 1, result.TotalErrors)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelError, "prometheus is configured but port is empty"))
+	})
+
+	t.Run("prometheus both empty", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Prometheus.Path = ""
+		config.Core.Prometheus.Port = ""
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+	})
+
+	t.Run("prometheus path empty and port empty", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+	})
+
+	t.Run("logs path parent dir does not exist", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Logging.LogsPath = "/nonexistent/dir/beelzebub.log"
+		result := ValidateCore(config, "beelzebub.yaml")
+		for _, issue := range result.Results[0].Issues {
+			t.Logf("issue: %+v", issue)
+		}
+		assert.Equal(t, 1, result.TotalWarnings)
+		assert.Equal(t, 0, result.TotalErrors)
+		assert.True(t, hasIssue(result.Results[0].Issues, LevelWarning, `logs path "/nonexistent/dir/beelzebub.log": parent directory "/nonexistent/dir" does not exist`))
+	})
+
+	t.Run("logs path empty", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Logging.LogsPath = ""
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+		assert.Equal(t, 0, result.TotalWarnings)
+	})
+
+	t.Run("logs path valid parent dir", func(t *testing.T) {
+		config := &BeelzebubCoreConfigurations{}
+		config.Core.Logging.LogsPath = "/tmp/beelzebub.log"
+		result := ValidateCore(config, "beelzebub.yaml")
+		assert.Equal(t, 0, result.TotalErrors)
+		assert.Equal(t, 0, result.TotalWarnings)
+	})
+}
+
+func TestValidateAddressFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		address   string
+		wantWarn  bool
+		warnMsg   string
+	}{
+		{":8080", ":8080", false, ""},
+		{"0.0.0.0:80", "0.0.0.0:80", false, ""},
+		{"/tmp/socket", "/tmp/socket", false, ""},
+		{"abc no colon", "abc", true, `address "abc" has invalid port format or port out of range (1-65535)`},
+		{":99999 port out of range", ":99999", true, `address ":99999" has invalid port format or port out of range (1-65535)`},
+		{":0 port zero", ":0", true, `address ":0" has invalid port format or port out of range (1-65535)`},
+		{":abc port not a number", ":abc", true, `address ":abc" has invalid port format or port out of range (1-65535)`},
+		{"[::1]:8080 IPv6", "[::1]:8080", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", tt.address, nil)
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantWarn {
+				assert.True(t, hasIssue(issues, LevelWarning, tt.warnMsg))
+			} else {
+				for _, issue := range issues {
+					assert.NotContains(t, issue.Message, "invalid port format")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCommandEmptyHandlerAndPlugin(t *testing.T) {
+	tests := []struct {
+		name     string
+		commands []Command
+		wantWarn bool
+	}{
+		{"handler set", []Command{{RegexStr: "test", Handler: "some-handler"}}, false},
+		{"plugin set", []Command{{RegexStr: "test", Plugin: "LLMHoneypot"}}, false},
+		{"both empty", []Command{{RegexStr: "test"}}, true},
+		{"both set", []Command{{RegexStr: "test", Handler: "h", Plugin: "LLMHoneypot"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", tt.commands)
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantWarn {
+				assert.True(t, hasIssue(issues, LevelWarning, "command[0] has empty handler and no plugin — matched requests will produce no output"))
+			} else {
+				assert.False(t, hasIssue(issues, LevelWarning, "command[0] has empty handler and no plugin"))
+			}
+		})
+	}
+}
+
+func TestValidateMalformedHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		commands []Command
+		wantWarn bool
+	}{
+		{"no headers", []Command{{RegexStr: "test", Headers: nil}}, false},
+		{"valid header", []Command{{RegexStr: "test", Headers: []string{"Content-Type: application/json"}}}, false},
+		{"malformed header", []Command{{RegexStr: "test", Headers: []string{"NoColonValue"}}}, true},
+		{"multiple headers one malformed", []Command{{RegexStr: "test", Headers: []string{"Content-Type: application/json", "NoColonValue"}}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := makeService("test.yaml", "http", ":8080", tt.commands)
+			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+			issues := findIssues(result, "test.yaml")
+
+			if tt.wantWarn {
+				assert.True(t, hasIssue(issues, LevelWarning, `command[0].headers has malformed entry (no colon): "NoColonValue"`))
+			} else {
+				for _, issue := range issues {
+					assert.NotContains(t, issue.Message, "malformed entry")
+				}
+			}
+		})
+	}
+}
+
+type mockValidator struct {
+	name   string
+	issues []ValidationIssue
+}
+
+func (m *mockValidator) Name() string { return m.name }
+
+func (m *mockValidator) Validate(config BeelzebubServiceConfiguration) []ValidationIssue {
+	return m.issues
+}
+
+func TestRegisterAndResetServiceValidators(t *testing.T) {
+	ResetServiceValidators()
+
+	mockV := &mockValidator{name: "mock", issues: []ValidationIssue{
+		{Level: LevelWarning, Message: "mock issue"},
+	}}
+	RegisterServiceValidator(mockV)
+
+	svc := makeService("test.yaml", "tcp", ":8080", nil)
+	result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+	issues := findIssues(result, "test.yaml")
+	assert.True(t, hasIssue(issues, LevelWarning, "mock issue"))
+
+	ResetServiceValidators()
+
+	result2 := Validate([]BeelzebubServiceConfiguration{svc}, nil)
+	issues2 := findIssues(result2, "test.yaml")
+	assert.False(t, hasIssue(issues2, LevelWarning, "mock issue"))
+}

--- a/internal/plugins/llm_validator.go
+++ b/internal/plugins/llm_validator.go
@@ -1,0 +1,67 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type LLMPluginValidator struct{}
+
+func (v *LLMPluginValidator) Name() string {
+	return LLMPluginName
+}
+
+func (v *LLMPluginValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if !usesPlugin(config, LLMPluginName) {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	switch config.Plugin.LLMProvider {
+	case "ollama", "openai":
+	case "":
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: "plugin LLMHoneypot requires llmProvider (valid: ollama, openai)",
+		})
+	default:
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: fmt.Sprintf("invalid llmProvider %q, valid: ollama, openai", config.Plugin.LLMProvider),
+		})
+	}
+
+	if config.Plugin.LLMModel == "" {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: "plugin LLMHoneypot requires llmModel",
+		})
+	}
+
+	if config.Plugin.LLMProvider == "openai" && config.Plugin.OpenAISecretKey == "" {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelWarning,
+			Message: "openAISecretKey is empty for openai provider, set OPEN_AI_SECRET_KEY env var at runtime or openAISecretKey in config",
+		})
+	}
+
+	return issues
+}
+
+func usesPlugin(config parser.BeelzebubServiceConfiguration, pluginName string) bool {
+	for _, cmd := range config.Commands {
+		if cmd.Plugin == pluginName {
+			return true
+		}
+	}
+	if config.FallbackCommand.Plugin == pluginName {
+		return true
+	}
+	return false
+}
+
+func init() {
+	parser.RegisterServiceValidator(&LLMPluginValidator{})
+}

--- a/internal/plugins/llm_validator_test.go
+++ b/internal/plugins/llm_validator_test.go
@@ -1,0 +1,126 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeLLMService(provider, model, secretKey string) parser.BeelzebubServiceConfiguration {
+	return parser.BeelzebubServiceConfiguration{
+		Commands: []parser.Command{
+			{RegexStr: "^(.+)$", Plugin: LLMPluginName},
+		},
+		Plugin: parser.Plugin{
+			LLMProvider:     provider,
+			LLMModel:        model,
+			OpenAISecretKey: secretKey,
+		},
+	}
+}
+
+func TestLLMPluginValidator_NotUsed(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := parser.BeelzebubServiceConfiguration{
+		Commands: []parser.Command{
+			{RegexStr: "^(.+)$", Plugin: "SomeOtherPlugin"},
+		},
+	}
+
+	issues := validator.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestLLMPluginValidator_EmptyProvider(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("", "llama3", "")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "requires llmProvider")
+}
+
+func TestLLMPluginValidator_InvalidProvider(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("invalid", "llama3", "")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "invalid llmProvider")
+}
+
+func TestLLMPluginValidator_ValidOllamaProvider(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("ollama", "llama3", "")
+
+	issues := validator.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestLLMPluginValidator_ValidOpenAIProvider(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("openai", "gpt-4o", "sk-test-key")
+
+	issues := validator.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestLLMPluginValidator_EmptyModel(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("ollama", "", "")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "requires llmModel")
+}
+
+func TestLLMPluginValidator_OpenAIEmptySecretKey(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("openai", "gpt-4o", "")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "openAISecretKey is empty")
+}
+
+func TestLLMPluginValidator_OllamaEmptySecretKey(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := makeLLMService("ollama", "llama3", "")
+
+	issues := validator.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestLLMPluginValidator_FallbackCommand(t *testing.T) {
+	validator := &LLMPluginValidator{}
+
+	config := parser.BeelzebubServiceConfiguration{
+		FallbackCommand: parser.Command{
+			Plugin: LLMPluginName,
+		},
+		Plugin: parser.Plugin{
+			LLMProvider: "",
+			LLMModel:    "",
+		},
+	}
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 2)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "requires llmProvider")
+	assert.Equal(t, "error", issues[1].Level)
+	assert.Contains(t, issues[1].Message, "requires llmModel")
+}

--- a/internal/plugins/maze_validator.go
+++ b/internal/plugins/maze_validator.go
@@ -1,0 +1,32 @@
+package plugins
+
+import (
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type MazePluginValidator struct{}
+
+func (v *MazePluginValidator) Name() string {
+	return MazePluginName
+}
+
+func (v *MazePluginValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if !usesPlugin(config, MazePluginName) {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	if config.Protocol != "http" {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelWarning,
+			Message: "plugin MazeHoneypot is only supported with http protocol",
+		})
+	}
+
+	return issues
+}
+
+func init() {
+	parser.RegisterServiceValidator(&MazePluginValidator{})
+}

--- a/internal/plugins/maze_validator_test.go
+++ b/internal/plugins/maze_validator_test.go
@@ -1,0 +1,72 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeMazeService(protocol string) parser.BeelzebubServiceConfiguration {
+	return parser.BeelzebubServiceConfiguration{
+		Protocol: protocol,
+		Commands: []parser.Command{
+			{RegexStr: "^(.+)$", Plugin: MazePluginName},
+		},
+	}
+}
+
+func TestMazePluginValidator_NotUsed(t *testing.T) {
+	validator := &MazePluginValidator{}
+
+	config := parser.BeelzebubServiceConfiguration{
+		Commands: []parser.Command{
+			{RegexStr: "^(.+)$", Plugin: "SomeOtherPlugin"},
+		},
+	}
+
+	issues := validator.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestMazePluginValidator_HTTPProtocol(t *testing.T) {
+	validator := &MazePluginValidator{}
+
+	config := makeMazeService("http")
+
+	issues := validator.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestMazePluginValidator_SSHProtocol(t *testing.T) {
+	validator := &MazePluginValidator{}
+
+	config := makeMazeService("ssh")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "only supported with http protocol")
+}
+
+func TestMazePluginValidator_TelnetProtocol(t *testing.T) {
+	validator := &MazePluginValidator{}
+
+	config := makeMazeService("telnet")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "only supported with http protocol")
+}
+
+func TestMazePluginValidator_EmptyProtocol(t *testing.T) {
+	validator := &MazePluginValidator{}
+
+	config := makeMazeService("")
+
+	issues := validator.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "only supported with http protocol")
+}

--- a/internal/protocols/strategies/HTTP/validator.go
+++ b/internal/protocols/strategies/HTTP/validator.go
@@ -1,0 +1,56 @@
+package HTTP
+
+import (
+	"os"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type HTTPValidator struct{}
+
+func (v *HTTPValidator) Name() string {
+	return "http"
+}
+
+func (v *HTTPValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if config.Protocol != "http" {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	if (config.TLSCertPath != "" && config.TLSKeyPath == "") || (config.TLSCertPath == "" && config.TLSKeyPath != "") {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: "both tlsCertPath and tlsKeyPath must be set for TLS, or neither",
+		})
+	}
+
+	if config.TLSCertPath != "" && config.TLSKeyPath != "" {
+		if _, err := os.Stat(config.TLSCertPath); os.IsNotExist(err) {
+			issues = append(issues, parser.ValidationIssue{
+				Level:   parser.LevelWarning,
+				Message: "tlsCertPath file does not exist",
+			})
+		}
+		if _, err := os.Stat(config.TLSKeyPath); os.IsNotExist(err) {
+			issues = append(issues, parser.ValidationIssue{
+				Level:   parser.LevelWarning,
+				Message: "tlsKeyPath file does not exist",
+			})
+		}
+	}
+
+	if len(config.Commands) > 0 && config.FallbackCommand.Handler == "" && config.FallbackCommand.Plugin == "" {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelWarning,
+			Message: "HTTP service has commands but no fallbackCommand — unmatched requests will return empty 200 OK",
+		})
+	}
+
+	return issues
+}
+
+func init() {
+	parser.RegisterServiceValidator(&HTTPValidator{})
+}

--- a/internal/protocols/strategies/HTTP/validator_test.go
+++ b/internal/protocols/strategies/HTTP/validator_test.go
@@ -1,0 +1,164 @@
+package HTTP
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPValidator_Name(t *testing.T) {
+	v := &HTTPValidator{}
+	assert.Equal(t, "http", v.Name())
+}
+
+func TestHTTPValidator_NotHTTPProtocol(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "ssh",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestHTTPValidator_BothTLSSet(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		TLSCertPath: "/proc/self/exe",
+		TLSKeyPath:  "/proc/self/exe",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestHTTPValidator_NoTLSSet(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestHTTPValidator_OnlyCert(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		TLSCertPath: "/tmp/cert.crt",
+		TLSKeyPath:  "",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "both tlsCertPath and tlsKeyPath must be set for TLS, or neither", issues[0].Message)
+}
+
+func TestHTTPValidator_OnlyKey(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		TLSCertPath: "",
+		TLSKeyPath:  "/tmp/cert.key",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "both tlsCertPath and tlsKeyPath must be set for TLS, or neither", issues[0].Message)
+}
+
+func TestHTTPValidator_TLSFilesExist(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		TLSCertPath: "/proc/self/exe",
+		TLSKeyPath:  "/proc/self/exe",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestHTTPValidator_TLSFileNotExist(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		TLSCertPath: "/nonexistent/cert.crt",
+		TLSKeyPath:  "/nonexistent/cert.key",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 2)
+	for _, issue := range issues {
+		assert.Equal(t, parser.LevelWarning, issue.Level)
+		assert.Contains(t, issue.Message, "does not exist")
+	}
+}
+
+func TestHTTPValidator_TLSOneFileNotExist(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		TLSCertPath: "/proc/self/exe",
+		TLSKeyPath:  "/nonexistent/cert.key",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "tlsKeyPath file does not exist")
+}
+
+func TestHTTPValidator_HasCommandsWithFallback(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+		Commands: []parser.Command{
+			{RegexStr: "^GET /api", Handler: "handler"},
+		},
+		FallbackCommand: parser.Command{Handler: "fallback"},
+	}
+	issues := v.Validate(config)
+	for _, issue := range issues {
+		assert.NotContains(t, issue.Message, "no fallbackCommand")
+	}
+}
+
+func TestHTTPValidator_HasCommandsWithoutFallback(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+		Commands: []parser.Command{
+			{RegexStr: "^GET /api", Handler: "handler"},
+		},
+	}
+	issues := v.Validate(config)
+	var found bool
+	for _, issue := range issues {
+		if issue.Message == "HTTP service has commands but no fallbackCommand — unmatched requests will return empty 200 OK" {
+			found = true
+			assert.Equal(t, parser.LevelWarning, issue.Level)
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestHTTPValidator_NoCommandsNoFallback(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+	}
+	issues := v.Validate(config)
+	for _, issue := range issues {
+		assert.NotContains(t, issue.Message, "no fallbackCommand")
+	}
+}
+
+func TestHTTPValidator_NoCommandsWithFallback(t *testing.T) {
+	v := &HTTPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+		FallbackCommand: parser.Command{Handler: "fallback"},
+	}
+	issues := v.Validate(config)
+	for _, issue := range issues {
+		assert.NotContains(t, issue.Message, "no fallbackCommand")
+	}
+}

--- a/internal/protocols/strategies/MCP/validator.go
+++ b/internal/protocols/strategies/MCP/validator.go
@@ -1,0 +1,49 @@
+package MCP
+
+import (
+	"fmt"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type MCPValidator struct{}
+
+func (v *MCPValidator) Name() string {
+	return "mcp"
+}
+
+func (v *MCPValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if config.Protocol != "mcp" {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	for _, tool := range config.Tools {
+		if tool.Name == "" {
+			issues = append(issues, parser.ValidationIssue{
+				Level:   parser.LevelWarning,
+				Message: "tool has no name defined",
+			})
+		}
+		if len(tool.Params) == 0 {
+			issues = append(issues, parser.ValidationIssue{
+				Level:   parser.LevelWarning,
+				Message: fmt.Sprintf("tool %q has no parameters defined", tool.Name),
+			})
+		}
+	}
+
+	if len(config.Tools) == 0 {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelWarning,
+			Message: "MCP service has no tools defined",
+		})
+	}
+
+	return issues
+}
+
+func init() {
+	parser.RegisterServiceValidator(&MCPValidator{})
+}

--- a/internal/protocols/strategies/MCP/validator_test.go
+++ b/internal/protocols/strategies/MCP/validator_test.go
@@ -1,0 +1,143 @@
+package MCP
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMCPValidator_Name(t *testing.T) {
+	v := &MCPValidator{}
+	assert.Equal(t, "mcp", v.Name())
+}
+
+func TestMCPValidator_NotMCPProtocol(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestMCPValidator_ToolWithParams(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools: []parser.Tool{
+			{
+				Name: "tool:user-account-manager",
+				Params: []parser.Param{
+					{Name: "user_id", Description: "The ID of the user"},
+				},
+			},
+		},
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestMCPValidator_ToolWithoutParams(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools: []parser.Tool{
+			{
+				Name:   "tool:no-params",
+				Params: nil,
+			},
+		},
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "tool:no-params")
+	assert.Contains(t, issues[0].Message, "has no parameters defined")
+}
+
+func TestMCPValidator_MultipleToolsOneEmpty(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools: []parser.Tool{
+			{
+				Name: "tool:with-params",
+				Params: []parser.Param{
+					{Name: "id", Description: "The ID"},
+				},
+			},
+			{
+				Name:   "tool:without-params",
+				Params: []parser.Param{},
+			},
+		},
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "tool:without-params")
+}
+
+func TestMCPValidator_NoTools(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools:    []parser.Tool{},
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Equal(t, "MCP service has no tools defined", issues[0].Message)
+}
+
+func TestMCPValidator_ToolEmptyName(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools: []parser.Tool{
+			{
+				Name:   "",
+				Params: []parser.Param{{Name: "id"}},
+			},
+		},
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "tool has no name defined")
+}
+
+func TestMCPValidator_WithTools(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools: []parser.Tool{
+			{
+				Name: "tool:user-account-manager",
+				Params: []parser.Param{
+					{Name: "user_id", Description: "The ID of the user"},
+				},
+			},
+		},
+	}
+	issues := v.Validate(config)
+	for _, issue := range issues {
+		assert.NotEqual(t, "MCP service has no tools defined", issue.Message)
+	}
+}
+
+func TestMCPValidator_ToolEmptyNameAndNoParams(t *testing.T) {
+	v := &MCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "mcp",
+		Tools: []parser.Tool{
+			{
+				Name:   "",
+				Params: nil,
+			},
+		},
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 2)
+}

--- a/internal/protocols/strategies/SSH/validator.go
+++ b/internal/protocols/strategies/SSH/validator.go
@@ -1,0 +1,40 @@
+package SSH
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type SSHValidator struct{}
+
+func (v *SSHValidator) Name() string {
+	return "ssh"
+}
+
+func (v *SSHValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if config.Protocol != "ssh" {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	if config.PasswordRegex == "" {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: "passwordRegex is required for ssh protocol",
+		})
+	} else if _, err := regexp.Compile(config.PasswordRegex); err != nil {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: fmt.Sprintf("passwordRegex is not a valid regex: %v", err),
+		})
+	}
+
+	return issues
+}
+
+func init() {
+	parser.RegisterServiceValidator(&SSHValidator{})
+}

--- a/internal/protocols/strategies/SSH/validator_test.go
+++ b/internal/protocols/strategies/SSH/validator_test.go
@@ -1,0 +1,93 @@
+package SSH
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSHValidator_Name(t *testing.T) {
+	v := &SSHValidator{}
+	assert.Equal(t, "ssh", v.Name())
+}
+
+func TestSSHValidator_NotSSHProtocol(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestSSHValidator_EmptyPasswordRegex(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:               "ssh",
+		PasswordRegex:          "",
+		DeadlineTimeoutSeconds: 60,
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "passwordRegex is required for ssh protocol", issues[0].Message)
+}
+
+func TestSSHValidator_InvalidPasswordRegex(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:               "ssh",
+		PasswordRegex:          "[",
+		DeadlineTimeoutSeconds: 60,
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "passwordRegex is not a valid regex")
+}
+
+func TestSSHValidator_ValidPasswordRegex(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:               "ssh",
+		PasswordRegex:          "^root$",
+		DeadlineTimeoutSeconds: 60,
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestSSHValidator_ZeroDeadline(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:               "ssh",
+		PasswordRegex:          "^root$",
+		DeadlineTimeoutSeconds: 0,
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestSSHValidator_ValidDeadline(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:               "ssh",
+		PasswordRegex:          "^root$",
+		DeadlineTimeoutSeconds: 60,
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestSSHValidator_MultipleIssues(t *testing.T) {
+	v := &SSHValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:      "ssh",
+		PasswordRegex: "",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "passwordRegex is required for ssh protocol", issues[0].Message)
+}

--- a/internal/protocols/strategies/TCP/validator.go
+++ b/internal/protocols/strategies/TCP/validator.go
@@ -1,0 +1,49 @@
+package TCP
+
+import (
+	"os"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type TCPValidator struct{}
+
+func (v *TCPValidator) Name() string {
+	return "tcp"
+}
+
+func (v *TCPValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if config.Protocol != "tcp" {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	if (config.TLSCertPath != "" && config.TLSKeyPath == "") || (config.TLSCertPath == "" && config.TLSKeyPath != "") {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: "both tlsCertPath and tlsKeyPath must be set for TLS, or neither",
+		})
+	}
+
+	if config.TLSCertPath != "" && config.TLSKeyPath != "" {
+		if _, err := os.Stat(config.TLSCertPath); os.IsNotExist(err) {
+			issues = append(issues, parser.ValidationIssue{
+				Level:   parser.LevelWarning,
+				Message: "tlsCertPath file does not exist",
+			})
+		}
+		if _, err := os.Stat(config.TLSKeyPath); os.IsNotExist(err) {
+			issues = append(issues, parser.ValidationIssue{
+				Level:   parser.LevelWarning,
+				Message: "tlsKeyPath file does not exist",
+			})
+		}
+	}
+
+	return issues
+}
+
+func init() {
+	parser.RegisterServiceValidator(&TCPValidator{})
+}

--- a/internal/protocols/strategies/TCP/validator_test.go
+++ b/internal/protocols/strategies/TCP/validator_test.go
@@ -1,0 +1,107 @@
+package TCP
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTCPValidator_Name(t *testing.T) {
+	v := &TCPValidator{}
+	assert.Equal(t, "tcp", v.Name())
+}
+
+func TestTCPValidator_NotTCPProtocol(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "http",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestTCPValidator_BothTLSSet(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "tcp",
+		TLSCertPath: "/proc/self/exe",
+		TLSKeyPath:  "/proc/self/exe",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestTCPValidator_NoTLSSet(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "tcp",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestTCPValidator_OnlyCert(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "tcp",
+		TLSCertPath: "/tmp/cert.crt",
+		TLSKeyPath:  "",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "both tlsCertPath and tlsKeyPath must be set for TLS, or neither", issues[0].Message)
+}
+
+func TestTCPValidator_OnlyKey(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "tcp",
+		TLSCertPath: "",
+		TLSKeyPath:  "/tmp/cert.key",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "both tlsCertPath and tlsKeyPath must be set for TLS, or neither", issues[0].Message)
+}
+
+func TestTCPValidator_TLSFilesExist(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "tcp",
+		TLSCertPath: "/proc/self/exe",
+		TLSKeyPath:  "/proc/self/exe",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestTCPValidator_TLSFilesNotExist(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "tcp",
+		TLSCertPath: "/nonexistent/cert.crt",
+		TLSKeyPath:  "/nonexistent/cert.key",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 2)
+	for _, issue := range issues {
+		assert.Equal(t, parser.LevelWarning, issue.Level)
+		assert.Contains(t, issue.Message, "does not exist")
+	}
+}
+
+func TestTCPValidator_TLSOneFileNotExist(t *testing.T) {
+	v := &TCPValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:    "tcp",
+		TLSCertPath: "/proc/self/exe",
+		TLSKeyPath:  "/nonexistent/cert.key",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelWarning, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "tlsKeyPath file does not exist")
+}

--- a/internal/protocols/strategies/TELNET/validator.go
+++ b/internal/protocols/strategies/TELNET/validator.go
@@ -1,0 +1,40 @@
+package TELNET
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+)
+
+type TELNETValidator struct{}
+
+func (v *TELNETValidator) Name() string {
+	return "telnet"
+}
+
+func (v *TELNETValidator) Validate(config parser.BeelzebubServiceConfiguration) []parser.ValidationIssue {
+	if config.Protocol != "telnet" {
+		return nil
+	}
+
+	var issues []parser.ValidationIssue
+
+	if config.PasswordRegex == "" {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: "passwordRegex is required for telnet protocol",
+		})
+	} else if _, err := regexp.Compile(config.PasswordRegex); err != nil {
+		issues = append(issues, parser.ValidationIssue{
+			Level:   parser.LevelError,
+			Message: fmt.Sprintf("passwordRegex is not a valid regex: %v", err),
+		})
+	}
+
+	return issues
+}
+
+func init() {
+	parser.RegisterServiceValidator(&TELNETValidator{})
+}

--- a/internal/protocols/strategies/TELNET/validator_test.go
+++ b/internal/protocols/strategies/TELNET/validator_test.go
@@ -1,0 +1,55 @@
+package TELNET
+
+import (
+	"testing"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTELNETValidator_Name(t *testing.T) {
+	v := &TELNETValidator{}
+	assert.Equal(t, "telnet", v.Name())
+}
+
+func TestTELNETValidator_NotTELNETProtocol(t *testing.T) {
+	v := &TELNETValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "ssh",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestTELNETValidator_EmptyPasswordRegex(t *testing.T) {
+	v := &TELNETValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol: "telnet",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Equal(t, "passwordRegex is required for telnet protocol", issues[0].Message)
+}
+
+func TestTELNETValidator_InvalidPasswordRegex(t *testing.T) {
+	v := &TELNETValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:      "telnet",
+		PasswordRegex: "[",
+	}
+	issues := v.Validate(config)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, parser.LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "passwordRegex is not a valid regex")
+}
+
+func TestTELNETValidator_ValidPasswordRegex(t *testing.T) {
+	v := &TELNETValidator{}
+	config := parser.BeelzebubServiceConfiguration{
+		Protocol:      "telnet",
+		PasswordRegex: "^root$",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


## Summary

Adds a configuration validation engine (`beelzebub validate`) that reports all errors and warnings across core and service configs before startup, replacing the basic listing that existed in the plugin-system branch.

> **Note:** This PR is dependent from #294 and #293 tracks previous conversation history for this PR.

## Changes

- **Core engine** (`internal/parser/validator.go`): `Validate()` for services (protocol, address, port, commands, plugins, TLS, collisions), `ValidateCore()` for core config (RabbitMQ, Cloud, Prometheus, logs), `ServiceValidator` interface with `init()`-based registration
- **Lenient parsing**: `ReadConfigurationsServicesForValidation()` collects all parse errors as `ValidationIssue` instead of failing on first
- **Protocol validators**: SSH (passwordRegex), TELNET (passwordRegex), HTTP (TLS, fallback), MCP (tools), TCP (TLS)
- **Plugin validators**: LLMHoneypot (provider, model, secretKey), MazeHoneypot (protocol)
- **CLI**: `cli/validate.go` rewritten to use the full validation engine

## Tests

~700+ lines of new tests, `go vet` clean. 
Expected Coverage: parser ~94%, plugins ~91%, overall ~86%

