### PR TITLE
fix: add context-based stop mechanism to fix data race in tests

### DIFF
--- a/internal/plugins/beelzebub-cloud.go
+++ b/internal/plugins/beelzebub-cloud.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -47,6 +48,8 @@ type beelzebubCloud struct {
 	AuthToken       string
 	client          *resty.Client
 	PollingInterval time.Duration
+	ctx             context.Context
+	cancel          context.CancelFunc
 }
 
 type HoneypotConfigResponseDTO struct {
@@ -57,11 +60,14 @@ type HoneypotConfigResponseDTO struct {
 }
 
 func InitBeelzebubCloud(uri, authToken string, enableVerifyConfigurationsChanged bool) *beelzebubCloud {
+	ctx, cancel := context.WithCancel(context.Background())
 	beelzebubCloud := &beelzebubCloud{
 		URI:             uri,
 		AuthToken:       authToken,
 		client:          resty.New(),
 		PollingInterval: 15 * time.Second,
+		ctx:             ctx,
+		cancel:          cancel,
 	}
 	if enableVerifyConfigurationsChanged {
 		go func() {
@@ -71,6 +77,10 @@ func InitBeelzebubCloud(uri, authToken string, enableVerifyConfigurationsChanged
 		}()
 	}
 	return beelzebubCloud
+}
+
+func (beelzebubCloud *beelzebubCloud) Stop() {
+	beelzebubCloud.cancel()
 }
 
 func (beelzebubCloud *beelzebubCloud) SendEvent(event tracer.Event) (bool, error) {
@@ -159,6 +169,11 @@ var exitFunction func(code int) = os.Exit
 func (beelzebubCloud *beelzebubCloud) verifyConfigurationsChanged() error {
 	var lastConfigurationsHash = ""
 	for {
+		select {
+		case <-beelzebubCloud.ctx.Done():
+			return nil
+		default:
+		}
 		log.Debug("Checking configurations...")
 		_, configurationsHash, err := beelzebubCloud.GetHoneypotsConfigurations()
 		if err != nil {
@@ -171,7 +186,12 @@ func (beelzebubCloud *beelzebubCloud) verifyConfigurationsChanged() error {
 			log.Debug("Configurations changed.")
 			exitFunction(0)
 		}
-		time.Sleep(beelzebubCloud.PollingInterval)
+
+		select {
+		case <-beelzebubCloud.ctx.Done():
+			return nil
+		case <-time.After(beelzebubCloud.PollingInterval):
+		}
 	}
 }
 

--- a/internal/plugins/beelzebub-cloud_test.go
+++ b/internal/plugins/beelzebub-cloud_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -240,15 +241,15 @@ func TestVerifyConfigurationsChanged(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	uri := "localhost:8081"
-	callCount := 0
+	var callCount atomic.Int64
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/honeypots", uri),
 		func(req *http.Request) (*http.Response, error) {
-			callCount++
+			callCount.Add(1)
 
 			config := "apiVersion: \"v1\"\nprotocol: \"ssh\"\naddress: \":2222\"\ndescription: \"SSH interactive ChatGPT\"\ncommands:\n  - regex: \"^(.+)$\"\n    plugin: \"LLMHoneypot\"\nserverVersion: \"OpenSSH\"\nserverName: \"ubuntu\"\npasswordRegex: \"^(root|qwerty|Smoker666|123456|jenkins|minecraft|sinus|alex|postgres|Ly123456)$\"\ndeadlineTimeoutSeconds: 60\nplugin:\n  llmModel: \"gpt-4o\"\n  openAISecretKey: \"1234\"\n"
 
-			if callCount > 1 {
+			if callCount.Load() > 1 {
 				config = "apiVersion: \"v1\"\nprotocol: \"ssh\"\naddress: \":2222\"\ndescription: \"SSH interactive ChatGPT MODIFIED\"\ncommands:\n  - regex: \"^(.+)$\"\n    plugin: \"LLMHoneypot\"\nserverVersion: \"OpenSSH\"\nserverName: \"ubuntu\"\npasswordRegex: \"^(root|qwerty|Smoker666|123456|jenkins|minecraft|sinus|alex|postgres|Ly123456)$\"\ndeadlineTimeoutSeconds: 60\nplugin:\n  llmModel: \"gpt-3.5-turbo\"\n  openAISecretKey: \"1234\"\n"
 			}
 
@@ -283,10 +284,12 @@ func TestVerifyConfigurationsChanged(t *testing.T) {
 	select {
 	case <-exitCalled:
 		assert.True(t, exitInvoked)
-		assert.Greater(t, callCount, 1)
+		assert.Greater(t, callCount.Load(), int64(1))
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for exitFunction")
 	}
+
+	beelzebubCloud.Stop()
 }
 
 func TestMapToEventDTO_WithHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #296 — `TestVerifyConfigurationsChanged` flaky test caused by a data race between the background goroutine and `httpmock.DeactivateAndReset()`.

## Root Cause

`verifyConfigurationsChanged()` runs an infinite loop with no stop mechanism. The test launches it with `go`, but when the test function returns (after `exitCalled` fires), the goroutine is still in `time.Sleep` or making an HTTP request. The deferred `httpmock.DeactivateAndReset()` modifies global HTTP state while the goroutine is still using it → data race.

## Solution

- Add `context.Context` and `cancel` to the `beelzebubCloud` struct
- Add `Stop()` method that cancels the context
- Replace `time.Sleep` with `select` on `ctx.Done()` + `time.After` — allows clean interruption
- Check `ctx.Done()` at the start of each loop iteration
- Make `callCount` thread-safe with `atomic.Int64`
- Call `beelzebubCloud.Stop()` in test teardown before `httpmock.DeactivateAndReset()`

## Testing

- Test passes 10/10 runs with `-race` flag (previously flaky)
- Full test suite (`go test ./... -race`) passes with zero data races
