### PR TITLE
docs: fix Code of Conduct link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Beelzebub Code of Conduct](https://github.com/beelzebub-labs/beelzebub/blob/master/CODE_OF_CONDUCT.md).
+[Beelzebub Code of Conduct](https://github.com/beelzebub-labs/beelzebub/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <mario.candela.personal@gmail.com>.
 


### PR DESCRIPTION
All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### What

Fix the Code of Conduct link in `CONTRIBUTING.md`, which pointed to the `master` branch (404). Now points to `main`.

Tiny one-liner doc fix. No code changes, no tests needed. 🙂