### PR TITLE
fix(tcp): preserve raw client bytes in trace events for binary protocols

### DIFF
--- a/internal/protocols/strategies/TCP/tcp.go
+++ b/internal/protocols/strategies/TCP/tcp.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/beelzebub-labs/beelzebub/v3/internal/historystore"
 	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
@@ -72,15 +73,20 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 	if len(servConf.Commands) == 0 {
 		buffer := make([]byte, 1024)
 		command := ""
+		commandRaw := ""
 
 		if n, err := conn.Read(buffer); err == nil {
 			command = string(buffer[:n])
+			if !utf8.Valid(buffer[:n]) {
+				commandRaw = hexEscapeNonPrintable(buffer[:n])
+			}
 		}
 
 		tr.TraceEvent(tracer.Event{
 			Msg:         "New TCP attempt",
 			Protocol:    tracer.TCP.String(),
 			Command:     command,
+			CommandRaw:  commandRaw,
 			Status:      tracer.Stateless.String(),
 			RemoteAddr:  conn.RemoteAddr().String(),
 			SourceIp:    host,
@@ -121,6 +127,14 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 		}
 
 		commandInput := strings.TrimRight(string(buffer[:n]), "\r\n")
+
+		// Preserve the exact bytes when they are not valid UTF-8 (binary
+		// protocols), so the forensic record survives string()'s U+FFFD
+		// substitution. Empty for UTF-8 traffic.
+		commandRaw := ""
+		if !utf8.Valid(buffer[:n]) {
+			commandRaw = hexEscapeNonPrintable(buffer[:n])
+		}
 
 		// Match command against regexes
 		matched := false
@@ -176,6 +190,7 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 					SourcePort:    port,
 					Status:        tracer.Interaction.String(),
 					Command:       commandInput,
+					CommandRaw:    commandRaw,
 					CommandOutput: commandOutput,
 					ID:            sessionID.String(),
 					Protocol:      tracer.TCP.String(),
@@ -196,6 +211,7 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 				SourcePort:  port,
 				Status:      tracer.Interaction.String(),
 				Command:     commandInput,
+				CommandRaw:  commandRaw,
 				ID:          sessionID.String(),
 				Protocol:    tracer.TCP.String(),
 				Description: servConf.Description,
@@ -211,4 +227,21 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 		ID:       sessionID.String(),
 		Protocol: tracer.TCP.String(),
 	})
+}
+
+// hexEscapeNonPrintable renders b as printable ASCII, emitting every
+// non-printable byte (and the backslash itself) as \xNN. The result is safe to
+// store in trace events, JSON, and TEXT columns while remaining reversible to
+// the original bytes.
+func hexEscapeNonPrintable(b []byte) string {
+	var sb strings.Builder
+	sb.Grow(len(b))
+	for _, c := range b {
+		if c >= 32 && c <= 126 && c != '\\' {
+			sb.WriteByte(c)
+		} else {
+			fmt.Fprintf(&sb, "\\x%02x", c)
+		}
+	}
+	return sb.String()
 }

--- a/internal/protocols/strategies/TCP/tcp_rawbytes_test.go
+++ b/internal/protocols/strategies/TCP/tcp_rawbytes_test.go
@@ -1,0 +1,118 @@
+package TCP
+
+import (
+	"net"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"github.com/beelzebub-labs/beelzebub/v3/internal/tracer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexEscapeNonPrintable_PreservesPrintable(t *testing.T) {
+	assert.Equal(t, "PING", hexEscapeNonPrintable([]byte("PING")))
+}
+
+func TestHexEscapeNonPrintable_EscapesCRLF(t *testing.T) {
+	assert.Equal(t, "\\x0d\\x0a", hexEscapeNonPrintable([]byte("\r\n")))
+}
+
+func TestHexEscapeNonPrintable_EscapesNullByte(t *testing.T) {
+	assert.Equal(t, "\\x00", hexEscapeNonPrintable([]byte{0x00}))
+}
+
+func TestHexEscapeNonPrintable_EscapesBackslash(t *testing.T) {
+	assert.Equal(t, "\\x5c", hexEscapeNonPrintable([]byte{'\\'}))
+}
+
+func TestHexEscapeNonPrintable_PreservesHighByte(t *testing.T) {
+	// A lone 0x80 is invalid UTF-8 and is exactly the kind of byte that
+	// string() would replace with U+FFFD. It must survive as \x80.
+	assert.Equal(t, "\\x80", hexEscapeNonPrintable([]byte{0x80}))
+}
+
+// A binary frame containing a non-UTF-8 byte (0x80, e.g. an LDAP BER tag)
+// must be recoverable from CommandRaw rather than lost to U+FFFD.
+func TestHandleTCPConnection_NonUTF8_PopulatesCommandRaw(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	mt := &mockTracer{}
+	servConf := parser.BeelzebubServiceConfiguration{
+		Description:            "test",
+		DeadlineTimeoutSeconds: 5,
+		Commands: []parser.Command{
+			{Name: "noop", Regex: regexp.MustCompile(`^never_matches$`), Handler: ""},
+		},
+	}
+	strategy := newStrategyWithSessions()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTCPConnection(server, servConf, mt, strategy)
+	}()
+
+	frame := []byte{0x30, 0x0c, 0x02, 0x01, 0x01, 0x80, 0x04, 0x00}
+	client.Write(frame)
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for connection handler")
+	}
+
+	var got *tracer.Event
+	for i := range mt.events {
+		if mt.events[i].CommandRaw != "" {
+			got = &mt.events[i]
+			break
+		}
+	}
+
+	assert.NotNil(t, got, "expected an event carrying CommandRaw")
+	if got != nil {
+		assert.Equal(t, hexEscapeNonPrintable(frame), got.CommandRaw)
+		assert.Contains(t, got.CommandRaw, "\\x80", "the 0x80 byte must be recoverable")
+	}
+}
+
+// Regression guard: plain ASCII input is valid UTF-8, so CommandRaw must stay
+// empty — existing events are byte-identical to before this change.
+func TestHandleTCPConnection_ASCII_LeavesCommandRawEmpty(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	mt := &mockTracer{}
+	servConf := parser.BeelzebubServiceConfiguration{
+		Description:            "test",
+		DeadlineTimeoutSeconds: 5,
+		Commands: []parser.Command{
+			{Name: "noop", Regex: regexp.MustCompile(`^never_matches$`), Handler: ""},
+		},
+	}
+	strategy := newStrategyWithSessions()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTCPConnection(server, servConf, mt, strategy)
+	}()
+
+	client.Write([]byte("anything\n"))
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for connection handler")
+	}
+
+	assert.NotEmpty(t, mt.events, "expected at least one traced event")
+	for _, e := range mt.events {
+		assert.Empty(t, e.CommandRaw, "ASCII traffic must not populate CommandRaw")
+	}
+}

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -17,6 +17,13 @@ type Event struct {
 	RemoteAddr      string
 	Protocol        string
 	Command         string
+	// CommandRaw is a hex-escaped (\xNN) rendering of the exact bytes the
+	// client sent. It is populated only when Command's UTF-8 string form would
+	// lose data (i.e. the input is not valid UTF-8, as happens with binary
+	// protocols), so the original bytes remain recoverable downstream. Empty —
+	// and omitted from JSON — for UTF-8 traffic, leaving existing events
+	// unchanged.
+	CommandRaw      string `json:",omitempty"`
 	CommandOutput   string
 	Status          string
 	Msg             string


### PR DESCRIPTION
## Problem

The TCP strategy records client input as `string(buffer[:n])`. Any non-UTF-8 byte is replaced with the Unicode replacement character (U+FFFD) before it reaches the trace event, so the original bytes are unrecoverable downstream.

This affects the binary-protocol service configs in `configurations/services/` — LDAP, MSSQL, SMB, RDP, VNC, MQTT, Memcached, PostgreSQL. For example, against the shipped `tcp-389-ldap.yaml`, a BER frame containing `0x80` is recorded as:

```
Command:    "... 04 00 � 00"   (hex: ... 04 00 ef bf bd 00)
```

The `0x80` is gone — exactly the kind of byte (protocol tags, exploit payloads, binary magic) that matters most forensically.

## Change

Adds an optional `CommandRaw` field to `tracer.Event`, populated **only when the input is not valid UTF-8** (i.e. only when `Command` would otherwise lose data). It holds a `\xNN`-escaped copy of the exact bytes received:

```
CommandRaw: "0\x0c\x02\x01\x01`\x07\x02\x01\x03\x04\x00\x80\x00"
```

- `json:",omitempty"` — events for UTF-8 traffic serialize identically to before; the field is absent.
- Gated on `!utf8.Valid(...)` — plain ASCII and `\r\n` / `\x00` line protocols are untouched, so there is no behavior change for existing configs.

## Tests

- `hexEscapeNonPrintable`: printable passthrough, CRLF, null byte, backslash, and high-byte (`0x80`) preservation.
- TCP loop: a non-UTF-8 frame populates `CommandRaw` with the exact bytes; plain ASCII input leaves `CommandRaw` empty (regression guard for the no-change-for-UTF-8 claim).

`go test -race ./...` passes.
