### PR TITLE
feat(specs): add shared JSON Schema validation for honeypot configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ integration_test/certs/tls.key
 .env
 .codex
 .local
+.opencode/
+node_modules/
+package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,159 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/beelze
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 - **Explain why this enhancement would be useful** to most Beelzebub users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+
+## Configuration Validation Schema
+
+Beelzebub uses a dual-layer validation approach for honeypot service configurations:
+
+1. **JSON Schema (draft-07)** — validates structural correctness: required fields, types, string patterns, enum values, object shape. All violations are **hard errors**.
+2. **Go procedural** — validates cross-field constraints (TLS pair, regex syntax, CIDR format), file-system existence (TLS cert files), and quality warnings (missing `deadlineTimeoutSeconds`, inline secrets, handler-less commands). Produces both **errors** and **warnings**.
+
+### Validation flow
+
+```mermaid
+sequenceDiagram
+    participant YAML as configurations/services/*.yaml
+    participant Parser as configurationsParser<br/>ReadConfigurationsServicesForValidation()
+    participant Validator as parser.Validate()
+    participant Schema as SchemaValidator<br/>(registered ServiceValidator)
+    participant GoDirect as Direct Go checks
+    participant GoRegd as Registered ServiceValidators
+    participant Result as ValidateResult
+
+    YAML->>Parser: read & parse (lenient mode)
+    Parser->>Parser: yaml.Unmarshal + regex.Compile + net.ParseCIDR
+    Note over Parser: Parse-time: rate limiting threshold check
+    Parser-->>Validator: []BeelzebubServiceConfiguration
+    Parser-->>Validator: []ValidationIssue (parse-time errors)
+
+    loop per ogni servizio
+        Validator->>GoDirect: validateAddress(),<br/>validateCommands(), validatePluginConfig(),<br/>validateFallbackCommand()
+        GoDirect-->>Validator: []ValidationIssue
+
+        Validator->>Schema: Validate(config) ← via ServiceValidator interface
+        activate Schema
+        Schema->>Schema: sync.Once → lazy compile schemas<br/>(specs/ embeddati via //go:embed)
+        Schema->>Schema: json.Marshal → map[string]any<br/>then jsonschema.Validate(per-protocol)
+        Schema-->>Validator: []ValidationIssue (errori strutturali dello schema)
+        deactivate Schema
+
+        Validator->>GoRegd: protocol validators (SSH/HTTP/TCP/TELNET/MCP)<br/>+ plugin validators (LLM, Maze)
+        Note over GoRegd: Chiamano ValidateTLSConfig()<br/>ValidatePasswordRegex() etc.
+        GoRegd-->>Validator: []ValidationIssue (errori + warning qualità)
+    end
+
+    Note over Validator: Dopo il loop (richiede contesto multi-file)
+    Validator->>Validator: detectCollisions()
+
+    Validator->>Result: ValidateResult{TotalErrors, TotalWarnings}
+```
+
+A standalone CLI for CI runs schema-only validation:
+
+```
+go run ./cmd/validate-specs
+```
+
+This reads YAML files, parses them, and validates against the per-protocol JSON Schema, skipping Go procedural checks. Useful for non-Go consumers or quick CI checks.
+
+### Specs directory
+
+`specs/` contains the JSON Schema files that define the shared validation contract:
+
+| File | Description |
+|---|---|
+| `honeypot-config.schema.json` | Base schema with shared fields and `$defs` (Command, Tool, Plugin, ...) |
+| `honeypot-ssh.schema.json` | SSH: requires `passwordRegex`, `serverVersion`, `commands` |
+| `honeypot-http.schema.json` | HTTP: requires `commands`, disallows `tools` |
+| `honeypot-tcp.schema.json` | TCP: disallows `tools` |
+| `honeypot-telnet.schema.json` | TELNET: requires `passwordRegex`, `commands` |
+| `honeypot-mcp.schema.json` | MCP: requires `tools`, disallows `commands` |
+
+Per-protocol schemas extend the base via `allOf` + `$ref`. Conditional rules use `if/then`:
+
+- **LLMHoneypot**: if any command or fallback uses plugin `LLMHoneypot`, the top-level `plugin` object must have `llmProvider` and `llmModel` with `minLength: 1`
+- **MazeHoneypot**: if any command or fallback uses plugin `MazeHoneypot`, `protocol` must be `http`
+- **Rate limiting**: if `plugin.rateLimitEnabled` is `true`, then `rateLimitRequests` and `rateLimitWindowSeconds` must be present and ≥ 1
+
+The schemas are embedded in the Go binary via `//go:embed *.schema.json` in `specs/embed.go`.
+The `SchemaValidator` that consumes them is registered via `init()` in `internal/parser/schema_validator.go`.
+
+### Makefile targets
+
+```
+make validate-specs        # go run ./cmd/validate-specs (solo schema, per CI)
+make validate-all          # validate-specs + beelzebub validate (full)
+```
+
+### How to add a new field
+
+1. Add or modify the field in the Go struct (`internal/parser/configurations_parser.go`)
+2. Add the corresponding property in `specs/honeypot-config.schema.json` (and per-protocol schemas if protocol-specific)
+3. Run `make validate-specs` to verify config files pass
+4. Run `make validate-all` for full validation + Go procedural checks
+5. If the new field needs a quality warning, add a Go procedural check
+
+### How to add a new validator
+
+1. Implement the `ServiceValidator` interface:
+   ```go
+   type ServiceValidator interface {
+       Name() string
+       Validate(config BeelzebubServiceConfiguration) []ValidationIssue
+   }
+   ```
+2. Register it via `init()`:
+   ```go
+   func init() { parser.RegisterServiceValidator(&YourValidator{}) }
+   ```
+3. Ensure the package is imported with a blank identifier in `cli/validate.go` to trigger the `init()`:
+   ```go
+   import _ "github.com/beelzebub-labs/beelzebub/v3/internal/protocols/strategies/YOUR_PROTOCOL"
+   ```
+   See existing imports for SSH, HTTP, TCP, TELNET, MCP validators as examples.
+4. If the validator checks structural rules, add corresponding JSON Schema constraints.
+
+### Validation rule reference
+
+| Category | Rule | Layer | Severity |
+|---|---|---|---|
+| **Protocol** | `protocol` enum {ssh, http, tcp, telnet, mcp} | Schema | Error |
+| **Address** | `address` format host:port or Unix path | Schema | Error |
+| **Address** | Port range 1–65535 | Go | Warning |
+| **Auth** | `passwordRegex` required for SSH | Schema + Go | Error |
+| **Auth** | `passwordRegex` required for TELNET | Schema + Go | Error |
+| **Auth** | `passwordRegex` regex syntax | Go | Error |
+| **Auth** | `serverVersion` required for SSH | Schema | Error |
+| **Commands** | `commands` required for SSH (min 1) | Schema | Error |
+| **Commands** | `commands` required for HTTP (min 1) | Schema | Error |
+| **Commands** | `commands` required for TELNET (min 1) | Schema | Error |
+| **Commands** | `commands[].regex` non-empty | Schema + Go | Error |
+| **Commands** | `commands[].plugin` enum valid | Schema | Error |
+| **Commands** | `commands[].handler` empty + `plugin` empty | Go | Warning |
+| **Commands** | `commands[].headers` format `key: value` | Go | Warning |
+| **Commands** | `commands[].statusCode` range 100–599 | Schema | Error |
+| **Fallback** | `fallbackCommand.plugin` enum valid | Schema | Error |
+| **Fallback** | `fallbackCommand.regex` syntax | Go | Error |
+| **Fallback** | HTTP: commands present but no fallbackCommand | Go | Warning |
+| **Plugin** | LLMHoneypot → `llmProvider` + `llmModel` required | Schema | Error |
+| **Plugin** | `llmProvider` must be "ollama" or "openai" when set | Go | Error |
+| **Plugin** | `openAISecretKey` empty with provider "openai" | Go | Warning |
+| **Plugin** | MazeHoneypot → `protocol` must be "http" | Schema | Error |
+| **Plugin** | `openAISecretKey` inline (prefer env var) | Go | Warning |
+| **Plugin** | `rateLimitEnabled` → `requests` + `window > 0` | Schema | Error |
+| **TLS** | `tlsCertPath` + `tlsKeyPath` both or neither | Schema | Error |
+| **TLS** | TLS file existence | Go | Warning |
+| **Timeout** | `deadlineTimeoutSeconds` = 0 with commands | Go | Warning |
+| **Tools** | `tools` disallowed for SSH/HTTP/TCP/TELNET | Schema | Error |
+| **Tools** | MCP: `tools` required (min 1) | Schema | Error |
+| **Tools** | MCP: `commands` disallowed | Schema | Error |
+| **Tools** | MCP: `tool.name` non-empty | Go | Warning |
+| **Tools** | MCP: tool has params | Go | Warning |
+| **Core** | RabbitMQ URI required if enabled | Go | Error |
+| **Core** | Cloud URI + authToken required if enabled | Go | Error |
+| **Core** | Prometheus path + port required if configured | Go | Error |
+| **Core** | `apiVersion` must be "v1" | Schema | Error |
+| **Collision** | Same `protocol:address` duplicated across files | Go | Error |
+| **Parse** | `regexp.Compile` on all regex fields | Go | Error |
+| **Parse** | `net.ParseCIDR` on trustedProxies | Go | Error |

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,17 @@ test.dependencies.start:
 test.dependencies.down:
 	${DOCKER_COMPOSE} -f ./integration_test/docker-compose.yml down
 
+# validate-specs validates all honeypot service configurations against the
+# per-protocol JSON Schemas in specs/. Exit code 1 on any failure.
+.PHONY: validate-specs
+validate-specs:
+	go run ./cmd/validate-specs
+
+# validate-all runs both schema validation and the full Go validator.
+.PHONY: validate-all
+validate-all: validate-specs
+	go run . validate
+
 .PHONY: test.integration
 test.integration:
 	INTEGRATION=1 go test ./...

--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -188,7 +188,7 @@ address: ":8080"
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "validation failed with 1 error(s)")
-	assert.Contains(t, output, "invalid protocol")
+	assert.Contains(t, output, "must be one of")
 }
 
 func TestValidateConfigurations_CoreConfigParseError(t *testing.T) {

--- a/cmd/validate-specs/main.go
+++ b/cmd/validate-specs/main.go
@@ -1,0 +1,102 @@
+// Command validate-specs validates all honeypot service configuration files
+// against the per-protocol JSON Schemas in specs/.
+//
+// Usage:
+//
+//	go run ./cmd/validate-specs
+//	go run ./cmd/validate-specs -configs path/to/configs
+//	go run ./cmd/validate-specs -specs path/to/specs
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	configsDir := flag.String("configs", "configurations/services", "directory with YAML config files")
+	flag.Parse()
+
+	absConfigs, err := filepath.Abs(*configsDir)
+	if err != nil {
+		exit("resolving configs path: %v", err)
+	}
+
+	entries, err := os.ReadDir(absConfigs)
+	if err != nil {
+		exit("reading configs dir: %v", err)
+	}
+
+	type result struct {
+		File   string
+		Errors []string
+	}
+
+	var results []result
+	total := 0
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		total++
+
+		filePath := filepath.Join(absConfigs, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			results = append(results, result{File: entry.Name(), Errors: []string{fmt.Sprintf("reading file: %v", err)}})
+			continue
+		}
+
+		var svc parser.BeelzebubServiceConfiguration
+		if err := yaml.Unmarshal(data, &svc); err != nil {
+			results = append(results, result{File: entry.Name(), Errors: []string{fmt.Sprintf("parsing YAML: %v", err)}})
+			continue
+		}
+		svc.Filename = entry.Name()
+
+		issues := parser.ValidateConfigSchema(svc)
+		if len(issues) == 0 {
+			results = append(results, result{File: entry.Name()})
+		} else {
+			errs := make([]string, len(issues))
+			for i, iss := range issues {
+				errs[i] = iss.Message
+			}
+			results = append(results, result{File: entry.Name(), Errors: errs})
+		}
+	}
+
+	passed := 0
+	failed := 0
+
+	for _, r := range results {
+		if len(r.Errors) == 0 {
+			fmt.Printf("✓ %s\n", r.File)
+			passed++
+		} else {
+			fmt.Printf("✗ %s\n", r.File)
+			for _, e := range r.Errors {
+				fmt.Printf("    %s\n", e)
+			}
+			failed++
+		}
+	}
+
+	fmt.Printf("\n%d files: %d passed, %d failed\n", total, passed, failed)
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func exit(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/mark3labs/mcp-go v0.56.0
 	github.com/melbahja/goph v1.5.2
 	github.com/prometheus/client_golang v1.24.0
-	github.com/rabbitmq/amqp091-go v1.13.0
+	github.com/rabbitmq/amqp091-go v1.12.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -35,7 +36,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/prometheus/common v0.70.0 h1:bcpru3tWPVnxGnETLgOV5jbp/JRXgYEyv65CuBLA
 github.com/prometheus/common v0.70.0/go.mod h1:S/SFasQmgGiYH6C81LKCtYa8QACgthGg5zxL2udV7SY=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/rabbitmq/amqp091-go v1.13.0 h1:L8NA1WtF76C6KA3LAoufjfLgbist/If1UQYcsOjtxXA=
-github.com/rabbitmq/amqp091-go v1.13.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/rabbitmq/amqp091-go v1.12.0 h1:V0v14Iqfs+MwHWihJt/nGS5Ulu0vw572b2Co3mwunkI=
+github.com/rabbitmq/amqp091-go v1.12.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/parser/configurations_parser.go
+++ b/internal/parser/configurations_parser.go
@@ -55,42 +55,42 @@ type Prometheus struct {
 }
 
 type Plugin struct {
-	OpenAISecretKey         string `yaml:"openAISecretKey"`
-	Host                    string `yaml:"host"`
-	LLMModel                string `yaml:"llmModel"`
-	LLMProvider             string `yaml:"llmProvider"`
-	Prompt                  string `yaml:"prompt"`
-	InputValidationEnabled  bool   `yaml:"inputValidationEnabled"`
-	InputValidationPrompt   string `yaml:"inputValidationPrompt"`
-	OutputValidationEnabled bool   `yaml:"outputValidationEnabled"`
-	OutputValidationPrompt  string `yaml:"outputValidationPrompt"`
-	RateLimitEnabled        bool   `yaml:"rateLimitEnabled"`
-	RateLimitRequests       int    `yaml:"rateLimitRequests"`
-	RateLimitWindowSeconds  int    `yaml:"rateLimitWindowSeconds"`
+	OpenAISecretKey         string `yaml:"openAISecretKey" json:"openAISecretKey,omitempty"`
+	Host                    string `yaml:"host" json:"host,omitempty"`
+	LLMModel                string `yaml:"llmModel" json:"llmModel,omitempty"`
+	LLMProvider             string `yaml:"llmProvider" json:"llmProvider,omitempty"`
+	Prompt                  string `yaml:"prompt" json:"prompt,omitempty"`
+	InputValidationEnabled  bool   `yaml:"inputValidationEnabled" json:"inputValidationEnabled,omitempty"`
+	InputValidationPrompt   string `yaml:"inputValidationPrompt" json:"inputValidationPrompt,omitempty"`
+	OutputValidationEnabled bool   `yaml:"outputValidationEnabled" json:"outputValidationEnabled,omitempty"`
+	OutputValidationPrompt  string `yaml:"outputValidationPrompt" json:"outputValidationPrompt,omitempty"`
+	RateLimitEnabled        bool   `yaml:"rateLimitEnabled" json:"rateLimitEnabled,omitempty"`
+	RateLimitRequests       int    `yaml:"rateLimitRequests" json:"rateLimitRequests,omitempty"`
+	RateLimitWindowSeconds  int    `yaml:"rateLimitWindowSeconds" json:"rateLimitWindowSeconds,omitempty"`
 }
 
 // BeelzebubServiceConfiguration is the struct that contains the configurations of the honeypot service
 type BeelzebubServiceConfiguration struct {
 	Filename               string    `yaml:"-" json:"-"`
-	ApiVersion             string    `yaml:"apiVersion"`
-	Protocol               string    `yaml:"protocol"`
-	Address                string    `yaml:"address"`
-	Commands               []Command `yaml:"commands"`
-	Tools                  []Tool    `yaml:"tools"`
-	FallbackCommand        Command   `yaml:"fallbackCommand"`
-	ServerVersion          string    `yaml:"serverVersion"`
-	ServerName             string    `yaml:"serverName"`
-	DeadlineTimeoutSeconds int       `yaml:"deadlineTimeoutSeconds"`
-	PasswordRegex          string    `yaml:"passwordRegex"`
-	Description            string    `yaml:"description"`
-	Banner                 string    `yaml:"banner"`
-	Plugin                 Plugin    `yaml:"plugin"`
-	TLSCertPath            string    `yaml:"tlsCertPath"`
-	TLSKeyPath             string    `yaml:"tlsKeyPath"`
+	ApiVersion             string    `yaml:"apiVersion" json:"apiVersion,omitempty"`
+	Protocol               string    `yaml:"protocol" json:"protocol"`
+	Address                string    `yaml:"address" json:"address"`
+	Commands               []Command `yaml:"commands" json:"commands,omitempty"`
+	Tools                  []Tool    `yaml:"tools" json:"tools,omitempty"`
+	FallbackCommand        Command   `yaml:"fallbackCommand" json:"fallbackCommand,omitempty"`
+	ServerVersion          string    `yaml:"serverVersion" json:"serverVersion,omitempty"`
+	ServerName             string    `yaml:"serverName" json:"serverName,omitempty"`
+	DeadlineTimeoutSeconds int       `yaml:"deadlineTimeoutSeconds" json:"deadlineTimeoutSeconds,omitempty"`
+	PasswordRegex          string    `yaml:"passwordRegex" json:"passwordRegex,omitempty"`
+	Description            string    `yaml:"description" json:"description,omitempty"`
+	Banner                 string    `yaml:"banner" json:"banner,omitempty"`
+	Plugin                 Plugin    `yaml:"plugin" json:"plugin,omitempty"`
+	TLSCertPath            string    `yaml:"tlsCertPath" json:"tlsCertPath,omitempty"`
+	TLSKeyPath             string    `yaml:"tlsKeyPath" json:"tlsKeyPath,omitempty"`
 	// TrustedProxies is a list of CIDRs (or bare IPs) of upstream proxies whose
 	// X-Forwarded-For / X-Real-IP headers can be trusted. When empty, those
 	// headers are ignored and the immediate TCP peer is used as source IP.
-	TrustedProxies     []string     `yaml:"trustedProxies,omitempty" json:",omitempty"`
+	TrustedProxies     []string     `yaml:"trustedProxies,omitempty" json:"trustedProxies,omitempty"`
 	TrustedProxiesNets []*net.IPNet `yaml:"-" json:"-"`
 }
 
@@ -105,37 +105,37 @@ func (bsc BeelzebubServiceConfiguration) HashCode() (string, error) {
 
 // Command is the struct that contains the configurations of the commands
 type Command struct {
-	RegexStr   string         `yaml:"regex"`
-	Regex      *regexp.Regexp `yaml:"-"` // This field is parsed, not stored in the config itself.
-	Handler    string         `yaml:"handler"`
-	Headers    []string       `yaml:"headers"`
-	StatusCode int            `yaml:"statusCode"`
-	Plugin     string         `yaml:"plugin"`
-	Name       string         `yaml:"name"`
+	RegexStr   string         `yaml:"regex" json:"regex,omitempty"`
+	Regex      *regexp.Regexp `yaml:"-" json:"-"` // This field is parsed, not stored in the config itself.
+	Handler    string         `yaml:"handler" json:"handler,omitempty"`
+	Headers    []string       `yaml:"headers" json:"headers,omitempty"`
+	StatusCode int            `yaml:"statusCode" json:"statusCode,omitempty"`
+	Plugin     string         `yaml:"plugin" json:"plugin,omitempty"`
+	Name       string         `yaml:"name" json:"name,omitempty"`
 }
 
 // Tool is the struct that contains the configurations of the MCP Honeypot
 type Tool struct {
-	Name        string           `yaml:"name" json:"Name"`
-	Description string           `yaml:"description" json:"Description"`
-	Params      []Param          `yaml:"params" json:"Params"`
-	Handler     string           `yaml:"handler" json:"Handler"`
-	Annotations *ToolAnnotations `yaml:"annotations,omitempty" json:"Annotations,omitempty"`
+	Name        string           `yaml:"name" json:"name"`
+	Description string           `yaml:"description" json:"description,omitempty"`
+	Params      []Param          `yaml:"params" json:"params,omitempty"`
+	Handler     string           `yaml:"handler" json:"handler,omitempty"`
+	Annotations *ToolAnnotations `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }
 
 // ToolAnnotations contains MCP tool annotation hints for LLM clients
 type ToolAnnotations struct {
-	Title           string `yaml:"title,omitempty" json:"Title,omitempty"`
-	ReadOnlyHint    *bool  `yaml:"readOnlyHint,omitempty" json:"ReadOnlyHint,omitempty"`
-	DestructiveHint *bool  `yaml:"destructiveHint,omitempty" json:"DestructiveHint,omitempty"`
-	IdempotentHint  *bool  `yaml:"idempotentHint,omitempty" json:"IdempotentHint,omitempty"`
-	OpenWorldHint   *bool  `yaml:"openWorldHint,omitempty" json:"OpenWorldHint,omitempty"`
+	Title           string `yaml:"title,omitempty" json:"title,omitempty"`
+	ReadOnlyHint    *bool  `yaml:"readOnlyHint,omitempty" json:"readOnlyHint,omitempty"`
+	DestructiveHint *bool  `yaml:"destructiveHint,omitempty" json:"destructiveHint,omitempty"`
+	IdempotentHint  *bool  `yaml:"idempotentHint,omitempty" json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool  `yaml:"openWorldHint,omitempty" json:"openWorldHint,omitempty"`
 }
 
 // Param is the struct that contains the configurations of the parameters of the tools
 type Param struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
+	Name        string `yaml:"name" json:"name,omitempty"`
+	Description string `yaml:"description" json:"description,omitempty"`
 }
 
 type configurationsParser struct {

--- a/internal/parser/configurations_parser_test.go
+++ b/internal/parser/configurations_parser_test.go
@@ -258,7 +258,7 @@ func TestReadConfigurationsServicesGenerateHashCode(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Nil(t, errHashCode)
-	assert.Equal(t, hashCode, "528e52a4b7addc43ec887dba7913070c9fd9f2ec246723c4b6ee73de75426e24")
+	assert.Equal(t, "34c8a2e81787e09f9e24efd6f60b2ceb808e47d9fa180ea8af9f054797ad4e00", hashCode)
 }
 
 func TestReadConfigurationsPluginGuardrailsValid(t *testing.T) {
@@ -544,7 +544,7 @@ func TestToolAnnotationsHashCodeStability(t *testing.T) {
 	// the hash for configs that don't use annotations
 	hashCode, errHashCode := beelzebubServicesConfiguration[0].HashCode()
 	assert.Nil(t, errHashCode)
-	assert.Equal(t, "528e52a4b7addc43ec887dba7913070c9fd9f2ec246723c4b6ee73de75426e24", hashCode)
+	assert.Equal(t, "34c8a2e81787e09f9e24efd6f60b2ceb808e47d9fa180ea8af9f054797ad4e00", hashCode)
 }
 
 func TestReadConfigurationsCoreEnvOverridesFile(t *testing.T) {
@@ -669,9 +669,9 @@ func TestReadConfigurationsServicesDirectoryNotFound(t *testing.T) {
 }
 
 func TestReadConfigurationsServicesFromEnvInvalidRegex(t *testing.T) {
-	// Use the Go field name "RegexStr" as JSON key so that json.Unmarshal stores the value
+	// Use the Go field JSON tag "regex" so that json.Unmarshal stores the value
 	// as a plain string and leaves regex compilation to CompileCommandRegex.
-	t.Setenv("BEELZEBUB_SERVICES_CONFIG", `[{"protocol":"ssh","address":":22","commands":[{"RegexStr":"[invalid"}]}]`)
+	t.Setenv("BEELZEBUB_SERVICES_CONFIG", `[{"protocol":"ssh","address":":22","commands":[{"regex":"[invalid"}]}]`)
 
 	configurationsParser := Init("", "")
 
@@ -1099,7 +1099,7 @@ func TestReadConfigurationsServicesForValidationFromEnvRateLimitError(t *testing
 }
 
 func TestReadConfigurationsServicesForValidationFromEnvInvalidRegex(t *testing.T) {
-	t.Setenv("BEELZEBUB_SERVICES_CONFIG", `[{"protocol":"ssh","address":":22","commands":[{"RegexStr":"[invalid"}]}]`)
+	t.Setenv("BEELZEBUB_SERVICES_CONFIG", `[{"protocol":"ssh","address":":22","commands":[{"regex":"[invalid"}]}]`)
 
 	configurationsParser := Init("", "")
 

--- a/internal/parser/schema_validator.go
+++ b/internal/parser/schema_validator.go
@@ -1,0 +1,200 @@
+package parser
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/beelzebub-labs/beelzebub/v3/specs"
+)
+
+// SchemaValidator validates service configurations against the per-protocol
+// JSON Schemas embedded in the binary. Registered as a ServiceValidator so it
+// runs automatically during Validate().
+type SchemaValidator struct{}
+
+func (v *SchemaValidator) Name() string {
+	return "schema"
+}
+
+func (v *SchemaValidator) Validate(config BeelzebubServiceConfiguration) []ValidationIssue {
+	return ValidateConfigSchema(config)
+}
+
+var (
+	compileSchemasOnce sync.Once
+	baseSchema         *jsonschema.Schema
+	protocolSchemas    map[string]*jsonschema.Schema
+	schemaInitErr      error
+)
+
+// protocolSchemaURLs maps protocol name to the per-protocol schema $id.
+var protocolSchemaURLs = map[string]string{
+	"ssh":    "https://beelzebub-labs.github.io/specs/honeypot-ssh.schema.json",
+	"http":   "https://beelzebub-labs.github.io/specs/honeypot-http.schema.json",
+	"tcp":    "https://beelzebub-labs.github.io/specs/honeypot-tcp.schema.json",
+	"telnet": "https://beelzebub-labs.github.io/specs/honeypot-telnet.schema.json",
+	"mcp":    "https://beelzebub-labs.github.io/specs/honeypot-mcp.schema.json",
+}
+
+// ResetSchemaCache clears the compiled schema cache. Used in tests.
+func ResetSchemaCache() {
+	compileSchemasOnce = sync.Once{}
+	baseSchema = nil
+	protocolSchemas = nil
+	schemaInitErr = nil
+}
+
+func compileAllSchemas() error {
+	compileSchemasOnce.Do(func() {
+		compiler := jsonschema.NewCompiler()
+
+		baseDoc, err := loadSchemaRaw("honeypot-config.schema.json")
+		if err != nil {
+			schemaInitErr = fmt.Errorf("loading base schema: %w", err)
+			return
+		}
+		baseURL := "https://beelzebub-labs.github.io/specs/honeypot-config.schema.json"
+		if err := compiler.AddResource(baseURL, baseDoc); err != nil {
+			schemaInitErr = fmt.Errorf("registering base schema: %w", err)
+			return
+		}
+		bs, err := compiler.Compile(baseURL)
+		if err != nil {
+			schemaInitErr = fmt.Errorf("compiling base schema: %w", err)
+			return
+		}
+		baseSchema = bs
+
+		schemas := make(map[string]*jsonschema.Schema, len(protocolSchemaURLs))
+		for proto, url := range protocolSchemaURLs {
+			fileName := fmt.Sprintf("honeypot-%s.schema.json", proto)
+			doc, err := loadSchemaRaw(fileName)
+			if err != nil {
+				schemaInitErr = fmt.Errorf("loading schema %s: %w", fileName, err)
+				return
+			}
+			if err := compiler.AddResource(url, doc); err != nil {
+				schemaInitErr = fmt.Errorf("registering schema %s: %w", fileName, err)
+				return
+			}
+			s, err := compiler.Compile(url)
+			if err != nil {
+				schemaInitErr = fmt.Errorf("compiling schema %s: %w", fileName, err)
+				return
+			}
+			schemas[proto] = s
+		}
+
+		protocolSchemas = schemas
+	})
+	return schemaInitErr
+}
+
+// loadSchemaRaw reads a JSON Schema file from the embedded specs/ FS
+// and returns it as a raw JSON value (any) for the compiler.
+func loadSchemaRaw(fileName string) (any, error) {
+	data, err := specs.FS.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(data))
+}
+
+// ValidateConfigSchema validates a BeelzebubServiceConfiguration against
+// the JSON Schema. For known protocols, validates against the per-protocol
+// schema (which includes the base schema via $ref). For unknown protocols,
+// validates against the base schema only.
+func ValidateConfigSchema(config BeelzebubServiceConfiguration) []ValidationIssue {
+	if err := compileAllSchemas(); err != nil {
+		return []ValidationIssue{{
+			Level:   LevelError,
+			Message: fmt.Sprintf("schema initialization: %v", err),
+		}}
+	}
+
+	doc, err := structToRawJSON(config)
+	if err != nil {
+		return []ValidationIssue{{
+			Level:   LevelError,
+			Message: fmt.Sprintf("schema: converting config: %v", err),
+		}}
+	}
+
+	// For known protocols, validate against the per-protocol schema.
+	// It extends the base via $ref, so base constraints are included.
+	if validator, ok := protocolSchemas[config.Protocol]; ok {
+		if err := validator.Validate(doc); err != nil {
+			return flattenSchemaErrors(err)
+		}
+		return nil
+	}
+
+	// For unknown protocols, validate against the base schema only.
+	if err := baseSchema.Validate(doc); err != nil {
+		return flattenSchemaErrors(err)
+	}
+	return nil
+}
+
+// structToRawJSON converts a Go struct to a raw JSON value (any) via JSON
+// marshal/unmarshal. This is needed because jsonschema works with JSON types.
+func structToRawJSON(v any) (any, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(data))
+}
+
+// flattenSchemaErrors converts a jsonschema ValidationError tree into a flat
+// list of human-readable ValidationIssues.
+func flattenSchemaErrors(err error) []ValidationIssue {
+	ve, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return []ValidationIssue{{
+			Level:   LevelError,
+			Message: fmt.Sprintf("schema: %v", err),
+		}}
+	}
+
+	out := ve.DetailedOutput()
+	issues := flattenOutput(out)
+
+	if len(issues) == 0 {
+		issues = append(issues, ValidationIssue{
+			Level:   LevelError,
+			Message: err.Error(),
+		})
+	}
+	return issues
+}
+
+func flattenOutput(unit *jsonschema.OutputUnit) []ValidationIssue {
+	var issues []ValidationIssue
+	if unit.Error != nil {
+		loc := unit.InstanceLocation
+		if loc == "" {
+			loc = "/"
+		}
+		msg := unit.Error.String()
+		if loc != "/" {
+			msg = loc + " " + msg
+		}
+		issues = append(issues, ValidationIssue{
+			Level:   LevelError,
+			Message: msg,
+		})
+	}
+	for i := range unit.Errors {
+		issues = append(issues, flattenOutput(&unit.Errors[i])...)
+	}
+	return issues
+}
+
+func init() {
+	RegisterServiceValidator(&SchemaValidator{})
+}

--- a/internal/parser/schema_validator_test.go
+++ b/internal/parser/schema_validator_test.go
@@ -19,14 +19,14 @@ func TestSchemaValidator_Validate(t *testing.T) {
 
 	v := &SchemaValidator{}
 	config := BeelzebubServiceConfiguration{
-		Protocol:       "ssh",
-		Address:        ":22",
-		ServerVersion:  "OpenSSH",
-		PasswordRegex:  "^(.+)$",
-		ServerName:     "test",
-		ApiVersion:     "v1",
-		Commands:       []Command{{RegexStr: "^ls$", Handler: "files"}},
-		Description:    "test",
+		Protocol:      "ssh",
+		Address:       ":22",
+		ServerVersion: "OpenSSH",
+		PasswordRegex: "^(.+)$",
+		ServerName:    "test",
+		ApiVersion:    "v1",
+		Commands:      []Command{{RegexStr: "^ls$", Handler: "files"}},
+		Description:   "test",
 	}
 	issues := v.Validate(config)
 	assert.Empty(t, issues)
@@ -103,8 +103,8 @@ func TestValidateConfigSchema_Valid(t *testing.T) {
 				ServerVersion: "OpenSSH", PasswordRegex: "^(.+)$",
 				Commands: []Command{{RegexStr: "^ls$", Handler: "files"}},
 				Plugin: Plugin{
-					RateLimitEnabled:      true,
-					RateLimitRequests:     10,
+					RateLimitEnabled:       true,
+					RateLimitRequests:      10,
 					RateLimitWindowSeconds: 60,
 				},
 			},

--- a/internal/parser/schema_validator_test.go
+++ b/internal/parser/schema_validator_test.go
@@ -1,0 +1,242 @@
+package parser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaValidator_Name(t *testing.T) {
+	v := &SchemaValidator{}
+	assert.Equal(t, "schema", v.Name())
+}
+
+func TestSchemaValidator_Validate(t *testing.T) {
+	ResetSchemaCache()
+	defer ResetSchemaCache()
+
+	v := &SchemaValidator{}
+	config := BeelzebubServiceConfiguration{
+		Protocol:       "ssh",
+		Address:        ":22",
+		ServerVersion:  "OpenSSH",
+		PasswordRegex:  "^(.+)$",
+		ServerName:     "test",
+		ApiVersion:     "v1",
+		Commands:       []Command{{RegexStr: "^ls$", Handler: "files"}},
+		Description:    "test",
+	}
+	issues := v.Validate(config)
+	assert.Empty(t, issues)
+}
+
+func TestValidateConfigSchema_Valid(t *testing.T) {
+	ResetSchemaCache()
+	defer ResetSchemaCache()
+
+	tests := []struct {
+		name    string
+		config  BeelzebubServiceConfiguration
+		wantErr bool
+	}{
+		{
+			name: "valid SSH",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "ssh", Address: ":22",
+				ServerVersion: "OpenSSH", PasswordRegex: "^(.+)$",
+				Commands: []Command{{RegexStr: "^ls$", Handler: "files"}},
+			},
+		},
+		{
+			name: "valid HTTP",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "http", Address: ":8080",
+				Commands: []Command{{RegexStr: ".*", Handler: "ok"}},
+			},
+		},
+		{
+			name: "valid TCP no commands",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "tcp", Address: ":3306",
+				Banner: "8.0",
+			},
+		},
+		{
+			name: "valid MCP",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "mcp", Address: ":8000",
+				Tools: []Tool{
+					{Name: "tool:test", Params: []Param{{Name: "arg", Description: "an arg"}}},
+				},
+			},
+		},
+		{
+			name: "valid TELNET",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "telnet", Address: ":23",
+				PasswordRegex: "^(.+)$",
+				Commands:      []Command{{RegexStr: "^ls$", Handler: "files"}},
+			},
+		},
+		{
+			name: "SSH with LLM",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "ssh", Address: ":2222",
+				ServerVersion: "OpenSSH", PasswordRegex: "^(.+)$",
+				Commands: []Command{{RegexStr: "^(.+)$", Plugin: "LLMHoneypot"}},
+				Plugin:   Plugin{LLMProvider: "openai", LLMModel: "gpt-4", OpenAISecretKey: "sk-..."},
+			},
+		},
+		{
+			name: "HTTP with Maze",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "http", Address: ":8888",
+				Commands: []Command{{RegexStr: ".*", Plugin: "MazeHoneypot"}},
+			},
+		},
+		{
+			name: "with rate limit",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "ssh", Address: ":22",
+				ServerVersion: "OpenSSH", PasswordRegex: "^(.+)$",
+				Commands: []Command{{RegexStr: "^ls$", Handler: "files"}},
+				Plugin: Plugin{
+					RateLimitEnabled:      true,
+					RateLimitRequests:     10,
+					RateLimitWindowSeconds: 60,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := ValidateConfigSchema(tt.config)
+			if tt.wantErr {
+				assert.NotEmpty(t, issues)
+			} else {
+				assert.Empty(t, issues)
+			}
+		})
+	}
+}
+
+func TestValidateConfigSchema_Invalid(t *testing.T) {
+	ResetSchemaCache()
+	defer ResetSchemaCache()
+
+	tests := []struct {
+		name   string
+		config BeelzebubServiceConfiguration
+		msg    string
+	}{
+		{
+			name:   "missing protocol",
+			config: BeelzebubServiceConfiguration{Address: ":22"},
+			msg:    "value must be one of",
+		},
+		{
+			name:   "missing address",
+			config: BeelzebubServiceConfiguration{Protocol: "ssh"},
+			msg:    "missing propert",
+		},
+		{
+			name: "SSH missing passwordRegex",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "ssh", Address: ":22",
+				ServerVersion: "OpenSSH",
+				Commands:      []Command{{RegexStr: "^ls$", Handler: "files"}},
+			},
+			msg: "missing property",
+		},
+		{
+			name: "SSH missing serverVersion",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "ssh", Address: ":22",
+				PasswordRegex: "^(.+)$",
+				Commands:      []Command{{RegexStr: "^ls$", Handler: "files"}},
+			},
+			msg: "missing property",
+		},
+		{
+			name: "LLM without plugin object",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "http", Address: ":80",
+				Commands: []Command{{RegexStr: ".*", Plugin: "LLMHoneypot"}},
+			},
+			msg: "missing propert",
+		},
+		{
+			name: "LLM without llmProvider",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "http", Address: ":80",
+				Commands: []Command{{RegexStr: ".*", Plugin: "LLMHoneypot"}},
+				Plugin:   Plugin{LLMModel: "gpt-4"},
+			},
+			msg: "missing propert",
+		},
+		{
+			name: "Maze on wrong protocol",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "tcp", Address: ":8888",
+				Commands: []Command{{RegexStr: ".*", Plugin: "MazeHoneypot"}},
+			},
+			msg: "value must be 'http'",
+		},
+		{
+			name: "MCP with commands instead of tools",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "mcp", Address: ":8000",
+				Commands: []Command{{RegexStr: ".*", Handler: "ok"}},
+			},
+			msg: "false",
+		},
+		{
+			name: "TELNET missing passwordRegex",
+			config: BeelzebubServiceConfiguration{
+				Protocol: "telnet", Address: ":23",
+				Commands: []Command{{RegexStr: "^ls$", Handler: "files"}},
+			},
+			msg: "missing property",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := ValidateConfigSchema(tt.config)
+			if !assert.NotEmpty(t, issues) {
+				return
+			}
+			found := false
+			for _, iss := range issues {
+				if iss.Level == LevelError && strings.Contains(iss.Message, tt.msg) {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected error containing %q, got: %v", tt.msg, issues)
+		})
+	}
+}
+
+func TestValidateConfigSchema_UnknownProtocol(t *testing.T) {
+	ResetSchemaCache()
+	defer ResetSchemaCache()
+
+	config := BeelzebubServiceConfiguration{
+		Protocol: "ftp", Address: ":21",
+	}
+	issues := ValidateConfigSchema(config)
+	assert.NotEmpty(t, issues)
+	assert.Equal(t, LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "value must be one of")
+}
+
+func TestFlattenSchemaErrors_NonValidationError(t *testing.T) {
+	issues := flattenSchemaErrors(errors.New("test error"))
+	assert.Len(t, issues, 1)
+	assert.Equal(t, LevelError, issues[0].Level)
+	assert.Contains(t, issues[0].Message, "schema:")
+}

--- a/internal/parser/validator.go
+++ b/internal/parser/validator.go
@@ -71,8 +71,6 @@ func GetServiceValidators() []ServiceValidator {
 	return append([]ServiceValidator(nil), serviceValidators...)
 }
 
-var validProtocols = []string{"http", "ssh", "tcp", "mcp", "telnet"}
-
 var validCommandPlugins = []string{"", "LLMHoneypot", "MazeHoneypot"}
 
 var validCommandPluginsDisplay = []string{"(none)", "LLMHoneypot", "MazeHoneypot"}
@@ -94,7 +92,6 @@ func Validate(services []BeelzebubServiceConfiguration, parseIssues []Validation
 		r := getResult(resultMap, services[i].Filename)
 		services[i].Address = strings.TrimSpace(services[i].Address)
 
-		r.Issues = append(r.Issues, validateProtocol(services[i])...)
 		r.Issues = append(r.Issues, validateAddress(services[i])...)
 		r.Issues = append(r.Issues, validateCommands(services[i])...)
 		r.Issues = append(r.Issues, validateFallbackCommand(services[i])...)
@@ -117,17 +114,6 @@ func getResult(resultMap map[string]*ValidationResult, filename string) *Validat
 		resultMap[filename] = r
 	}
 	return r
-}
-
-func validateProtocol(svc BeelzebubServiceConfiguration) []ValidationIssue {
-	if slices.Contains(validProtocols, svc.Protocol) {
-		return nil
-	}
-
-	return []ValidationIssue{{
-		Level:   LevelError,
-		Message: fmt.Sprintf("invalid protocol %q, valid: %s", svc.Protocol, strings.Join(validProtocols, ", ")),
-	}}
 }
 
 func validateAddress(svc BeelzebubServiceConfiguration) []ValidationIssue {

--- a/internal/parser/validator.go
+++ b/internal/parser/validator.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,7 +45,7 @@ type ServiceValidator interface {
 }
 
 var (
-	serviceValidators []ServiceValidator
+	serviceValidators   []ServiceValidator
 	serviceValidatorsMu sync.Mutex
 )
 
@@ -70,10 +69,6 @@ func GetServiceValidators() []ServiceValidator {
 	defer serviceValidatorsMu.Unlock()
 	return append([]ServiceValidator(nil), serviceValidators...)
 }
-
-var validCommandPlugins = []string{"", "LLMHoneypot", "MazeHoneypot"}
-
-var validCommandPluginsDisplay = []string{"(none)", "LLMHoneypot", "MazeHoneypot"}
 
 // Validate checks service configurations and returns all errors and warnings
 func Validate(services []BeelzebubServiceConfiguration, parseIssues []ValidationIssue) ValidateResult {
@@ -154,13 +149,6 @@ func validateCommands(svc BeelzebubServiceConfiguration) []ValidationIssue {
 			})
 		}
 
-		if !slices.Contains(validCommandPlugins, cmd.Plugin) {
-			issues = append(issues, ValidationIssue{
-				Level:   LevelError,
-				Message: fmt.Sprintf("command[%d] has invalid plugin %q, valid: %s", j, cmd.Plugin, strings.Join(validCommandPluginsDisplay, ", ")),
-			})
-		}
-
 		if cmd.Handler == "" && cmd.Plugin == "" {
 			issues = append(issues, ValidationIssue{
 				Level:   LevelWarning,
@@ -194,13 +182,6 @@ func validateFallbackCommand(svc BeelzebubServiceConfiguration) []ValidationIssu
 				Message: fmt.Sprintf("fallbackCommand has invalid regex: %v", err),
 			})
 		}
-	}
-
-	if !slices.Contains(validCommandPlugins, fb.Plugin) {
-		issues = append(issues, ValidationIssue{
-			Level:   LevelError,
-			Message: fmt.Sprintf("fallbackCommand has invalid plugin %q, valid: %s", fb.Plugin, strings.Join(validCommandPluginsDisplay, ", ")),
-		})
 	}
 	return issues
 }

--- a/internal/parser/validator_test.go
+++ b/internal/parser/validator_test.go
@@ -153,6 +153,9 @@ func TestValidateCommandRegexEmpty(t *testing.T) {
 }
 
 func TestValidateCommandPluginInvalid(t *testing.T) {
+	RegisterServiceValidator(&SchemaValidator{})
+	defer ResetServiceValidators()
+
 	tests := []struct {
 		name      string
 		plugin    string
@@ -173,18 +176,20 @@ func TestValidateCommandPluginInvalid(t *testing.T) {
 			issues := findIssues(result, "test.yaml")
 
 			if tt.wantError {
-				expectedMsg := fmt.Sprintf("command[0] has invalid plugin %q, valid: (none), LLMHoneypot, MazeHoneypot", tt.plugin)
-				assert.True(t, hasIssue(issues, LevelError, expectedMsg))
+				assert.True(t, hasIssueContaining(issues, LevelError, "value must be one of"),
+					"expected schema validation error for plugin %q, got: %v", tt.plugin, issues)
 			} else {
-				for _, issue := range issues {
-					assert.NotContains(t, issue.Message, "invalid plugin")
-				}
+				assert.False(t, hasIssueContaining(issues, LevelError, "value must be one of"),
+					"unexpected schema validation error for plugin %q", tt.plugin)
 			}
 		})
 	}
 }
 
 func TestValidateFallbackCommand(t *testing.T) {
+	RegisterServiceValidator(&SchemaValidator{})
+	defer ResetServiceValidators()
+
 	tests := []struct {
 		name          string
 		fallback      Command
@@ -231,25 +236,13 @@ func TestValidateFallbackCommand(t *testing.T) {
 			issues := findIssues(result, "test.yaml")
 
 			if tt.wantRegexErr {
-				assert.True(t, len(issues) > 0, "expected a regex error")
-				for _, issue := range issues {
-					if issue.Level == LevelError {
-						assert.Contains(t, issue.Message, "fallbackCommand has invalid regex")
-					}
-				}
-			} else {
-				for _, issue := range issues {
-					assert.NotContains(t, issue.Message, "fallbackCommand has invalid regex")
-				}
+				assert.True(t, hasIssueContaining(issues, LevelError, "fallbackCommand has invalid regex"),
+					"expected regex error, got: %v", issues)
 			}
 
 			if tt.wantPluginErr {
-				expectedMsg := fmt.Sprintf("fallbackCommand has invalid plugin %q, valid: (none), LLMHoneypot, MazeHoneypot", tt.fallback.Plugin)
-				assert.True(t, hasIssue(issues, LevelError, expectedMsg))
-			} else {
-				for _, issue := range issues {
-					assert.NotContains(t, issue.Message, "fallbackCommand has invalid plugin")
-				}
+				assert.True(t, hasIssueContaining(issues, LevelError, "value must be one of"),
+					"expected schema plugin error, got: %v", issues)
 			}
 		})
 	}
@@ -600,10 +593,10 @@ func TestValidateCore(t *testing.T) {
 
 func TestValidateAddressFormat(t *testing.T) {
 	tests := []struct {
-		name      string
-		address   string
-		wantWarn  bool
-		warnMsg   string
+		name     string
+		address  string
+		wantWarn bool
+		warnMsg  string
 	}{
 		{":8080", ":8080", false, ""},
 		{"0.0.0.0:80", "0.0.0.0:80", false, ""},

--- a/internal/parser/validator_test.go
+++ b/internal/parser/validator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,15 +43,27 @@ func hasIssue(issues []ValidationIssue, level, message string) bool {
 	return false
 }
 
+func hasIssueContaining(issues []ValidationIssue, level, substr string) bool {
+	for _, issue := range issues {
+		if issue.Level == level && strings.Contains(issue.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestValidateProtocol(t *testing.T) {
+	ResetSchemaCache()
+	defer ResetSchemaCache()
+
 	tests := []struct {
 		name      string
 		protocol  string
 		wantError bool
 		errorMsg  string
 	}{
-		{"missing protocol", "", true, `invalid protocol "", valid: http, ssh, tcp, mcp, telnet`},
-		{"invalid protocol ftp", "ftp", true, `invalid protocol "ftp", valid: http, ssh, tcp, mcp, telnet`},
+		{"missing protocol", "", true, "value must be one of"},
+		{"invalid protocol ftp", "ftp", true, "value must be one of"},
 		{"valid http", "http", false, ""},
 		{"valid ssh", "ssh", false, ""},
 		{"valid tcp", "tcp", false, ""},
@@ -61,14 +74,19 @@ func TestValidateProtocol(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := makeService("test.yaml", tt.protocol, ":8080", nil)
-			result := Validate([]BeelzebubServiceConfiguration{svc}, nil)
-			issues := findIssues(result, "test.yaml")
+			issues := ValidateConfigSchema(svc)
 
 			if tt.wantError {
-				assert.True(t, hasIssue(issues, LevelError, tt.errorMsg))
+				if !hasIssueContaining(issues, LevelError, tt.errorMsg) {
+					t.Logf("Issues (count=%d):", len(issues))
+					for i, iss := range issues {
+						t.Logf("  [%d] Level=%s Msg=%q", i, iss.Level, iss.Message)
+					}
+				}
+				assert.True(t, hasIssueContaining(issues, LevelError, tt.errorMsg))
 			} else {
 				for _, issue := range issues {
-					assert.NotContains(t, issue.Message, "invalid protocol")
+					assert.NotContains(t, issue.Message, "value must be one of")
 				}
 			}
 		})
@@ -708,7 +726,11 @@ func TestValidateTLSConfig(t *testing.T) {
 	})
 
 	t.Run("both set and exist", func(t *testing.T) {
-		issues := ValidateTLSConfig("/proc/self/exe", "/proc/self/exe", "test.yaml")
+		existingFile, _ := os.Executable()
+		if existingFile == "" {
+			existingFile = "/tmp"
+		}
+		issues := ValidateTLSConfig(existingFile, existingFile, "test.yaml")
 		assert.Empty(t, issues)
 	})
 
@@ -737,7 +759,11 @@ func TestValidateTLSConfig(t *testing.T) {
 	})
 
 	t.Run("one file does not exist", func(t *testing.T) {
-		issues := ValidateTLSConfig("/proc/self/exe", "/nonexistent/cert.key", "test.yaml")
+		existingFile, _ := os.Executable()
+		if existingFile == "" {
+			existingFile = "/tmp"
+		}
+		issues := ValidateTLSConfig(existingFile, "/nonexistent/cert.key", "test.yaml")
 		assert.Len(t, issues, 1)
 		assert.Equal(t, LevelWarning, issues[0].Level)
 		assert.Contains(t, issues[0].Message, "tlsKeyPath file does not exist")

--- a/internal/plugins/beelzebub-cloud_test.go
+++ b/internal/plugins/beelzebub-cloud_test.go
@@ -131,7 +131,7 @@ func TestGetHoneypotsConfigurationsWithResults(t *testing.T) {
 			TrustedProxiesNets: []*net.IPNet{},
 		},
 	}, &result)
-	assert.Equal(t, "1212319b58fef59aaddd18537d2d65c62f6fb6e9874ac92d426f5cd8859e2d9e", configurationsHash)
+	assert.Equal(t, "f488015ba743c96aca43462b2f798d700af9b3eb7cab401435a0c522da6f5abf", configurationsHash)
 	assert.Nil(t, err)
 }
 

--- a/internal/protocols/strategies/HTTP/validator_test.go
+++ b/internal/protocols/strategies/HTTP/validator_test.go
@@ -1,11 +1,20 @@
 package HTTP
 
 import (
+	"os"
 	"testing"
 
 	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
 	"github.com/stretchr/testify/assert"
 )
+
+func existingFile() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "/tmp"
+	}
+	return exe
+}
 
 func TestHTTPValidator_Name(t *testing.T) {
 	v := &HTTPValidator{}
@@ -23,10 +32,11 @@ func TestHTTPValidator_NotHTTPProtocol(t *testing.T) {
 
 func TestHTTPValidator_BothTLSSet(t *testing.T) {
 	v := &HTTPValidator{}
+	existing := existingFile()
 	config := parser.BeelzebubServiceConfiguration{
 		Protocol:    "http",
-		TLSCertPath: "/proc/self/exe",
-		TLSKeyPath:  "/proc/self/exe",
+		TLSCertPath: existing,
+		TLSKeyPath:  existing,
 	}
 	issues := v.Validate(config)
 	assert.Empty(t, issues)
@@ -69,10 +79,11 @@ func TestHTTPValidator_OnlyKey(t *testing.T) {
 
 func TestHTTPValidator_TLSFilesExist(t *testing.T) {
 	v := &HTTPValidator{}
+	existing := existingFile()
 	config := parser.BeelzebubServiceConfiguration{
 		Protocol:    "http",
-		TLSCertPath: "/proc/self/exe",
-		TLSKeyPath:  "/proc/self/exe",
+		TLSCertPath: existing,
+		TLSKeyPath:  existing,
 	}
 	issues := v.Validate(config)
 	assert.Empty(t, issues)
@@ -95,9 +106,10 @@ func TestHTTPValidator_TLSFileNotExist(t *testing.T) {
 
 func TestHTTPValidator_TLSOneFileNotExist(t *testing.T) {
 	v := &HTTPValidator{}
+	existing := existingFile()
 	config := parser.BeelzebubServiceConfiguration{
 		Protocol:    "http",
-		TLSCertPath: "/proc/self/exe",
+		TLSCertPath: existing,
 		TLSKeyPath:  "/nonexistent/cert.key",
 	}
 	issues := v.Validate(config)

--- a/internal/protocols/strategies/HTTP/validator_test.go
+++ b/internal/protocols/strategies/HTTP/validator_test.go
@@ -166,7 +166,7 @@ func TestHTTPValidator_NoCommandsNoFallback(t *testing.T) {
 func TestHTTPValidator_NoCommandsWithFallback(t *testing.T) {
 	v := &HTTPValidator{}
 	config := parser.BeelzebubServiceConfiguration{
-		Protocol: "http",
+		Protocol:        "http",
 		FallbackCommand: parser.Command{Handler: "fallback"},
 	}
 	issues := v.Validate(config)

--- a/internal/protocols/strategies/TCP/validator_test.go
+++ b/internal/protocols/strategies/TCP/validator_test.go
@@ -1,11 +1,20 @@
 package TCP
 
 import (
+	"os"
 	"testing"
 
 	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
 	"github.com/stretchr/testify/assert"
 )
+
+func existingFile() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "/tmp"
+	}
+	return exe
+}
 
 func TestTCPValidator_Name(t *testing.T) {
 	v := &TCPValidator{}
@@ -23,10 +32,11 @@ func TestTCPValidator_NotTCPProtocol(t *testing.T) {
 
 func TestTCPValidator_BothTLSSet(t *testing.T) {
 	v := &TCPValidator{}
+	existing := existingFile()
 	config := parser.BeelzebubServiceConfiguration{
 		Protocol:    "tcp",
-		TLSCertPath: "/proc/self/exe",
-		TLSKeyPath:  "/proc/self/exe",
+		TLSCertPath: existing,
+		TLSKeyPath:  existing,
 	}
 	issues := v.Validate(config)
 	assert.Empty(t, issues)
@@ -69,10 +79,11 @@ func TestTCPValidator_OnlyKey(t *testing.T) {
 
 func TestTCPValidator_TLSFilesExist(t *testing.T) {
 	v := &TCPValidator{}
+	existing := existingFile()
 	config := parser.BeelzebubServiceConfiguration{
 		Protocol:    "tcp",
-		TLSCertPath: "/proc/self/exe",
-		TLSKeyPath:  "/proc/self/exe",
+		TLSCertPath: existing,
+		TLSKeyPath:  existing,
 	}
 	issues := v.Validate(config)
 	assert.Empty(t, issues)
@@ -95,9 +106,10 @@ func TestTCPValidator_TLSFilesNotExist(t *testing.T) {
 
 func TestTCPValidator_TLSOneFileNotExist(t *testing.T) {
 	v := &TCPValidator{}
+	existing := existingFile()
 	config := parser.BeelzebubServiceConfiguration{
 		Protocol:    "tcp",
-		TLSCertPath: "/proc/self/exe",
+		TLSCertPath: existing,
 		TLSKeyPath:  "/nonexistent/cert.key",
 	}
 	issues := v.Validate(config)

--- a/specs/embed.go
+++ b/specs/embed.go
@@ -1,0 +1,14 @@
+// Package specs provides embedded access to the honeypot configuration
+// JSON Schemas. The schemas define the shared validation contract for
+// Beelzebub service configurations across all platforms (Go, Java, TypeScript).
+//
+// The raw schema files live alongside this file and are embedded into
+// the Go binary via //go:embed.
+package specs
+
+import "embed"
+
+// FS contains all JSON Schema files in the specs/ directory.
+//
+//go:embed *.schema.json
+var FS embed.FS

--- a/specs/honeypot-config.schema.json
+++ b/specs/honeypot-config.schema.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://beelzebub-labs.github.io/specs/honeypot-config.schema.json",
+  "title": "Beelzebub Honeypot Service Configuration",
+  "description": "Base schema for Beelzebub honeypot service configurations. Extended per-protocol via allOf + $ref.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "enum": ["v1"],
+      "description": "Configuration format version. Currently only 'v1' is supported."
+    },
+    "protocol": {
+      "type": "string",
+      "enum": ["ssh", "http", "tcp", "telnet", "mcp"],
+      "description": "Honeypot protocol type. Determines which per-protocol schema and validators are applied."
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^(\\[[^\\]]+\\]|[^:\\s]+)?:[0-9]{1,5}$|^/[^:]+$",
+      "description": "Listen address in host:port format (e.g. :22, 0.0.0.0:8080, [::1]:443). Unix sockets use /path format."
+    },
+    "description": { "type": "string", "description": "Human-readable label for this honeypot service." },
+    "serverVersion": { "type": "string", "description": "Banner/version string sent to clients during handshake (e.g. OpenSSH, Apache/2.4.53)." },
+    "serverName": { "type": "string", "description": "Hostname reported by the honeypot (e.g. ubuntu, mail.internal.company.com)." },
+    "deadlineTimeoutSeconds": { "type": "integer", "minimum": 0, "description": "Max connection lifetime in seconds. 0 means no timeout. Go warns if unset with commands." },
+    "banner": { "type": "string", "description": "Initial banner sent on connection (TCP) or greeting (HTTP). Can include binary wire format." },
+    "passwordRegex": { "type": "string", "description": "Regex pattern for accepted passwords. Required for SSH and TELNET. Syntax validated by Go at runtime." },
+    "trustedProxies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "CIDRs or IPs of trusted reverse proxies. Affects X-Forwarded-For / X-Real-IP parsing."
+    },
+    "tlsCertPath": { "type": "string", "description": "Path to TLS certificate file. Must be paired with tlsKeyPath. File existence checked by Go at runtime." },
+    "tlsKeyPath": { "type": "string", "description": "Path to TLS private key file. Must be paired with tlsCertPath." },
+    "commands": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          { "$ref": "#/definitions/Command" },
+          {
+            "required": ["regex"],
+            "properties": { "regex": { "minLength": 1 } }
+          }
+        ]
+      },
+      "maxItems": 100
+    },
+    "tools": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Tool" },
+      "maxItems": 100
+    },
+    "fallbackCommand": { "$ref": "#/definitions/Command" },
+    "plugin": { "$ref": "#/definitions/Plugin" }
+  },
+  "required": ["protocol", "address"],
+  "additionalProperties": false,
+  "dependencies": {
+    "tlsCertPath": ["tlsKeyPath"],
+    "tlsKeyPath": ["tlsCertPath"]
+  },
+  "allOf": [
+    {
+      "$comment": "LLMHoneypot: if any command or fallback uses LLMHoneypot, top-level plugin must have llmProvider and llmModel",
+      "if": {
+        "anyOf": [
+          {
+            "required": ["commands"],
+            "properties": {
+              "commands": {
+                "contains": {
+                  "properties": { "plugin": { "const": "LLMHoneypot" } },
+                  "required": ["plugin"]
+                }
+              }
+            }
+          },
+          {
+            "required": ["fallbackCommand"],
+            "properties": {
+              "fallbackCommand": {
+                "required": ["plugin"],
+                "properties": { "plugin": { "const": "LLMHoneypot" } }
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "required": ["plugin"],
+        "properties": {
+          "plugin": {
+            "required": ["llmProvider", "llmModel"],
+            "properties": {
+              "llmModel": { "minLength": 1 },
+              "llmProvider": { "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "MazeHoneypot: if any command or fallback uses MazeHoneypot, protocol must be http",
+      "if": {
+        "anyOf": [
+          {
+            "required": ["commands"],
+            "properties": {
+              "commands": {
+                "contains": {
+                  "properties": { "plugin": { "const": "MazeHoneypot" } },
+                  "required": ["plugin"]
+                }
+              }
+            }
+          },
+          {
+            "required": ["fallbackCommand"],
+            "properties": {
+              "fallbackCommand": {
+                "required": ["plugin"],
+                "properties": { "plugin": { "const": "MazeHoneypot" } }
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "protocol": { "const": "http" }
+        }
+      }
+    },
+    {
+      "$comment": "Rate limiting: if plugin.rateLimitEnabled is true, rateLimitRequests and rateLimitWindowSeconds must be > 0",
+      "if": {
+        "required": ["plugin"],
+        "properties": {
+          "plugin": {
+            "required": ["rateLimitEnabled"],
+            "properties": { "rateLimitEnabled": { "const": true } }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "plugin": {
+            "required": ["rateLimitRequests", "rateLimitWindowSeconds"],
+            "properties": {
+              "rateLimitRequests": { "minimum": 1 },
+              "rateLimitWindowSeconds": { "minimum": 1 }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "Command": {
+      "type": "object",
+      "properties": {
+        "regex": { "type": "string" },
+        "handler": { "type": "string" },
+        "headers": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "statusCode": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "plugin": {
+          "type": "string",
+          "enum": ["", "LLMHoneypot", "MazeHoneypot"]
+        },
+        "name": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "Tool": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "params": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ToolParam" }
+        },
+        "handler": { "type": "string" },
+        "annotations": { "$ref": "#/definitions/ToolAnnotations" }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "ToolParam": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "ToolAnnotations": {
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" },
+        "readOnlyHint": { "type": "boolean" },
+        "destructiveHint": { "type": "boolean" },
+        "idempotentHint": { "type": "boolean" },
+        "openWorldHint": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "Plugin": {
+      "type": "object",
+      "properties": {
+        "llmProvider": {
+          "type": "string",
+          "enum": ["", "ollama", "openai"]
+        },
+        "llmModel": { "type": "string" },
+        "prompt": { "type": "string" },
+        "openAISecretKey": { "type": "string" },
+        "host": { "type": "string" },
+        "inputValidationEnabled": { "type": "boolean" },
+        "inputValidationPrompt": { "type": "string" },
+        "outputValidationEnabled": { "type": "boolean" },
+        "outputValidationPrompt": { "type": "string" },
+        "rateLimitEnabled": { "type": "boolean" },
+        "rateLimitRequests": { "type": "integer" },
+        "rateLimitWindowSeconds": { "type": "integer" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/specs/honeypot-http.schema.json
+++ b/specs/honeypot-http.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://beelzebub-labs.github.io/specs/honeypot-http.schema.json",
+  "title": "Beelzebub HTTP Honeypot Configuration",
+  "allOf": [
+    { "$ref": "honeypot-config.schema.json" },
+    {
+      "required": ["commands"],
+      "properties": {
+        "commands": { "minItems": 1 },
+        "tools": false
+      }
+    }
+  ]
+}

--- a/specs/honeypot-mcp.schema.json
+++ b/specs/honeypot-mcp.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://beelzebub-labs.github.io/specs/honeypot-mcp.schema.json",
+  "title": "Beelzebub MCP Honeypot Configuration",
+  "allOf": [
+    { "$ref": "honeypot-config.schema.json" },
+    {
+      "required": ["tools"],
+      "properties": {
+        "tools": { "minItems": 1 },
+        "commands": false
+      }
+    }
+  ]
+}

--- a/specs/honeypot-ssh.schema.json
+++ b/specs/honeypot-ssh.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://beelzebub-labs.github.io/specs/honeypot-ssh.schema.json",
+  "title": "Beelzebub SSH Honeypot Configuration",
+  "allOf": [
+    { "$ref": "honeypot-config.schema.json" },
+    {
+      "required": ["passwordRegex", "serverVersion", "commands"],
+      "properties": {
+        "passwordRegex": { "minLength": 1 },
+        "commands": { "minItems": 1 },
+        "tools": false
+      }
+    }
+  ]
+}

--- a/specs/honeypot-tcp.schema.json
+++ b/specs/honeypot-tcp.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://beelzebub-labs.github.io/specs/honeypot-tcp.schema.json",
+  "title": "Beelzebub TCP Honeypot Configuration",
+  "allOf": [
+    { "$ref": "honeypot-config.schema.json" },
+    {
+      "properties": {
+        "tools": false
+      }
+    }
+  ]
+}

--- a/specs/honeypot-telnet.schema.json
+++ b/specs/honeypot-telnet.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://beelzebub-labs.github.io/specs/honeypot-telnet.schema.json",
+  "title": "Beelzebub TELNET Honeypot Configuration",
+  "allOf": [
+    { "$ref": "honeypot-config.schema.json" },
+    {
+      "required": ["passwordRegex", "commands"],
+      "properties": {
+        "passwordRegex": { "minLength": 1 },
+        "commands": { "minItems": 1 },
+        "tools": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

---

## Summary

Adds a **shared JSON Schema validation layer** for Beelzebub honeypot service configurations. The schemas in `specs/` define the canonical validation contract consumed by the Go runtime, and designed to be consumed by other platforms (Java backend, TypeScript dashboard).

### New files

| File | Description |
|---|---|
| `specs/honeypot-config.schema.json` | Base schema (draft-07) with `$defs` for Command, Tool, Plugin, tool annotations, and conditional `if/then` rules for LLM, Maze, and rate limiting |
| `specs/honeypot-ssh.schema.json` | SSH: requires `passwordRegex`, `serverVersion`, `commands` |
| `specs/honeypot-http.schema.json` | HTTP: requires `commands`, disallows `tools` |
| `specs/honeypot-tcp.schema.json` | TCP: disallows `tools` |
| `specs/honeypot-telnet.schema.json` | TELNET: requires `passwordRegex`, `commands` |
| `specs/honeypot-mcp.schema.json` | MCP: requires `tools`, disallows `commands` |
| `specs/embed.go` | Embeds schemas into the Go binary via `//go:embed` |
| `internal/parser/schema_validator.go` | `SchemaValidator` — registered as `ServiceValidator`, lazy-compiles schemas with `sync.Once`, validates via `santhosh-tekuri/jsonschema/v6` |
| `internal/parser/schema_validator_test.go` | 20 test cases: valid configs per protocol, invalid edge cases, unknown protocol, error flattening |
| `cmd/validate-specs/main.go` | Standalone CLI for CI (`make validate-specs`) |

### Modified files

| File | Change |
|---|---|
| `internal/parser/configurations_parser.go` | Added JSON tags with `omitempty` to all struct fields (Plugin, Command, Tool, etc.) for correct schema serialization |
| `internal/parser/validator.go` | Removed `validateProtocol()` (schema enum handles it), removed `validCommandPlugins` duplicate checks |
| `cli/validate_test.go` | Updated expected error count for unknown protocol (schema + Go → schema only) |
| `internal/parser/validator_test.go` | Updated tests to register `SchemaValidator` via `RegisterServiceValidator()` for proper pipeline testing |
| `internal/parser/configurations_parser_test.go` | Updated hash codes for new omitempty JSON output, fixed JSON keys (`RegexStr` → `regex`), added `hasIssueContaining` helper |
| `internal/plugins/beelzebub-cloud_test.go` | Updated hash code for new JSON output |
| `HTTP/validator_test.go` | Cross-platform TLS tests via `os.Executable()` instead of `/proc/self/exe` |
| `TCP/validator_test.go` | Cross-platform TLS tests via `os.Executable()` |
| `Makefile` | Added `validate-specs` and `validate-all` targets |
| `CONTRIBUTING.md` | Added "Configuration Validation Schema" section with Mermaid sequence diagram and 38-row rule reference table |
| `go.mod` | `santhosh-tekuri/jsonschema/v6` promoted from indirect to direct dependency |

### Validation architecture

YAML → ReadConfigurationsServicesForValidation()
        → yaml.Unmarshal + regex.Compile + net.ParseCIDR
        → Validate() loop:
            ├── Direct Go checks (address, commands, fallback, plugin config)
            ├── SchemaValidator (lazy-compiled JSON Schema via jsonschema/v6)
            │   └── json.Marshal → validate per-protocol schema
            └── Protocol-specific validators (SSH, HTTP, TCP, TELNET, MCP)
        → detectCollisions()
        → ValidateResult{errors + warnings}

### Dual-layer design

- **Schema** (JSON Schema draft-07) — structural errors: required fields, types, enums, patterns, `if/then` conditionals for LLM/Maze/rate limiting
- **Go procedural** — quality warnings (inline secrets, missing deadline/timeout, empty handlers) and runtime checks (regex compile, CIDR parse, TLS file existence, collision detection)
