### PR TITLE
docs: Added note on LLMhoneypot guardrails in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Environment variable overrides are supported for all fields (e.g. `BEELZEBUB_RAB
 
 Each decoy service is defined in a separate YAML file placed in the `services/` directory. The `protocol` field determines the deception engine used. Commands use `regex` for request matching and either a static `handler` or a `plugin` reference for dynamic responses.
 
+When using the **LLMHoneypot** plugin, it is highly recommended to use guardrails to prevent the LLM from being jailbroken or otherwise manipulated in ways that could compromise the honeypot. See the [LLMHoneypot plugin documentation](https://docs.beelzebub.ai/basics/beelzebub-api-v1#llmhoneypot-plugin) for details.
+
 ## Deception Services
 
 ### MCP Deception Service


### PR DESCRIPTION
As discussed with @mariocandela I'm adding in the README a note to use guardrails when using the LLMHoneypot plugin. It is a short paragraph that links to the docs.